### PR TITLE
Feature: skip tests and contexts with `xit` and `xdescribe`

### DIFF
--- a/src/main/java/com/greghaskins/spectrum/Context.java
+++ b/src/main/java/com/greghaskins/spectrum/Context.java
@@ -96,5 +96,17 @@ class Context implements Executable {
         executables.add(childContext);
     }
 
+	public void skipTest(String behavior) {
+		Description testDescription = Description.createTestDescription(description.getClassName(), behavior);
+		description.addChild(testDescription);
+		executables.add(new Executable() {
+			
+			@Override
+			public void execute(RunNotifier notifier) {
+				notifier.fireTestIgnored(testDescription);
+			}
+		});
+	}
+
 
 }

--- a/src/main/java/com/greghaskins/spectrum/Context.java
+++ b/src/main/java/com/greghaskins/spectrum/Context.java
@@ -96,17 +96,17 @@ class Context implements Executable {
         executables.add(childContext);
     }
 
-	public void skipTest(String behavior) {
-		Description testDescription = Description.createTestDescription(description.getClassName(), behavior);
-		description.addChild(testDescription);
-		executables.add(new Executable() {
-			
-			@Override
-			public void execute(RunNotifier notifier) {
-				notifier.fireTestIgnored(testDescription);
-			}
-		});
-	}
+    public void skipTest(final String behavior) {
+        final Description testDescription = Description.createTestDescription(description.getClassName(), behavior);
+        description.addChild(testDescription);
+        executables.add(new Executable() {
+
+            @Override
+            public void execute(final RunNotifier notifier) {
+                notifier.fireTestIgnored(testDescription);
+            }
+        });
+    }
 
 
 }

--- a/src/main/java/com/greghaskins/spectrum/Spectrum.java
+++ b/src/main/java/com/greghaskins/spectrum/Spectrum.java
@@ -51,6 +51,18 @@ public class Spectrum extends Runner {
     }
 
     /**
+     * Temporarily skip a test; <em>it will not be run.</em> To re-enable, switch to {@link it it()}.
+     *
+     * @param behavior
+     *            Description of the behavior
+     * @param block
+     *            {@link Block} that will not be executed
+     */
+    public static void xit(final String behavior, final Block block) {
+        getCurrentContext().skipTest(behavior);
+    }
+    
+    /**
      * Declare a {@link Block} to be run before each test in the current context.
      *
      * <p>

--- a/src/test/java/specs/ExampleSpec.java
+++ b/src/test/java/specs/ExampleSpec.java
@@ -7,6 +7,7 @@ import static com.greghaskins.spectrum.Spectrum.beforeEach;
 import static com.greghaskins.spectrum.Spectrum.describe;
 import static com.greghaskins.spectrum.Spectrum.it;
 import static com.greghaskins.spectrum.Spectrum.value;
+import static com.greghaskins.spectrum.Spectrum.xit;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
@@ -24,7 +25,6 @@ import org.junit.runner.RunWith;
 import com.greghaskins.spectrum.Spectrum;
 import com.greghaskins.spectrum.Spectrum.Block;
 import com.greghaskins.spectrum.Spectrum.Value;
-
 
 @RunWith(Spectrum.class)
 public class ExampleSpec {{
@@ -169,6 +169,15 @@ public class ExampleSpec {{
 
         it("cleans up after running all tests in the describe block", () -> {
             assertThat(numbers, is(empty()));
+        });
+
+    });
+
+    describe("Pending/ignored specs", () -> {
+
+        xit("can be declared using `xit`", () -> {
+            // this will not run
+            assertThat(true, is(false));
         });
 
     });

--- a/src/test/java/specs/SkipSpec.java
+++ b/src/test/java/specs/SkipSpec.java
@@ -1,0 +1,47 @@
+package specs;
+
+import static com.greghaskins.spectrum.Spectrum.describe;
+import static com.greghaskins.spectrum.Spectrum.it;
+import static com.greghaskins.spectrum.Spectrum.xit;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+
+import com.greghaskins.spectrum.Spectrum;
+
+import helpers.SpectrumRunner;
+
+@RunWith(Spectrum.class)
+public class SkipSpec {{
+	
+	describe("tests using xit", () -> {
+		
+		it("should be ignored", () -> {
+			final Result result = SpectrumRunner.run(getSpecWithSkippedTest());
+			assertThat(result.getIgnoreCount(), is(1));
+		});
+	});
+}
+
+private static final Class<?> getSpecWithSkippedTest(){
+    class Spec {{
+
+        describe("a valid context", () -> {
+
+            xit("with one ignored test", () -> {
+				
+			});
+            
+            it("and one passing test", () -> {
+				assertThat(true, is(true));
+			});
+
+        });
+
+    }}
+    return Spec.class;
+}
+
+}


### PR DESCRIPTION
To resolve #5 