### PR TITLE
Adding `xit` and `xdescribe` to allow Ignored specs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,42 @@ describe("Focused specs", () -> {
 });
 ```
 
+### Ignored Specs
+
+You can ignore the runner on particular spec with `xit` or a suite with `xdescribe` so that only those specs get executed.
+
+> from [IgnoredSpecs.java](src/test/java/specs/IgnoredSpecs.java)
+
+```java
+describe("Ignored specs", () -> {
+
+    xit("is ignored and will not run", () -> {
+        throw new Exception();
+    });
+
+    it("is not ignored and will run", () -> {
+        assertThat(true, is(true));
+    });
+
+    xdescribe("an ignored suite", () -> {
+
+        it("will not run", () -> {
+            throw new Exception();
+        });
+
+        describe("with nesting", () -> {
+            it("all its specs", () -> {
+                throw new Exception();
+            });
+            
+            fit("including focused specs", () -> {
+                throw new Exception();
+            });
+        });
+    });
+});
+```
+
 ## Supported Features
 
 Spectrum moving toward a `1.0` release with close alignment to Jasmine's test declaration API. The library already supports a nice subset of those features:
@@ -208,7 +244,7 @@ Spectrum moving toward a `1.0` release with close alignment to Jasmine's test de
 - [x] `beforeEach` / `afterEach`
 - [x] `beforeAll` / `afterAll`
 - [x] `fit` / `fdescribe`
-- [ ] `xit` / `xdescribe`
+- [x] `xit` / `xdescribe`
 
 ### Non-Features
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ describe("Focused specs", () -> {
 
 ### Ignored Specs
 
-You can ignore the runner on particular spec with `xit` or a suite with `xdescribe` so that only those specs get executed.
+You can ignore the runner on particular spec with `xit` or a suite with `xdescribe` so that only those specs get ignored. Nested focused specs will also be ignored.
 
 > from [IgnoredSpecs.java](src/test/java/specs/IgnoredSpecs.java)
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ describe("Ignored specs", () -> {
             it("all its specs", () -> {
                 throw new Exception();
             });
-            
+
             fit("including focused specs", () -> {
                 throw new Exception();
             });

--- a/src/main/java/com/greghaskins/spectrum/Child.java
+++ b/src/main/java/com/greghaskins/spectrum/Child.java
@@ -13,4 +13,6 @@ interface Child {
 
   void focus();
 
+  void ignore();
+
 }

--- a/src/main/java/com/greghaskins/spectrum/Parent.java
+++ b/src/main/java/com/greghaskins/spectrum/Parent.java
@@ -8,7 +8,7 @@ interface Parent {
 
   Parent NONE = new Parent() {
     @Override
-    public void focus(Child child) { }
+    public void focus(Child child) {}
 
     @Override
     public boolean isIgnored() {

--- a/src/main/java/com/greghaskins/spectrum/Parent.java
+++ b/src/main/java/com/greghaskins/spectrum/Parent.java
@@ -4,10 +4,15 @@ interface Parent {
 
   void focus(Child child);
 
-  static final Parent NONE = new Parent() {
+  boolean isIgnored();
+
+  Parent NONE = new Parent() {
+    @Override
+    public void focus(Child child) { }
 
     @Override
-    public void focus(final Child child) {}
+    public boolean isIgnored() {
+      return false;
+    }
   };
-
 }

--- a/src/main/java/com/greghaskins/spectrum/Spec.java
+++ b/src/main/java/com/greghaskins/spectrum/Spec.java
@@ -11,11 +11,13 @@ class Spec implements Child {
   private final Block block;
   private final Description description;
   private final Parent parent;
+  private boolean ignored = false;
 
   public Spec(final Description description, final Block block, final Parent parent) {
     this.description = description;
     this.block = block;
     this.parent = parent;
+    this.ignored = parent.isIgnored();
   }
 
   @Override
@@ -25,6 +27,11 @@ class Spec implements Child {
 
   @Override
   public void run(final RunNotifier notifier) {
+    if (this.ignored) {
+      notifier.fireTestIgnored(this.description);
+      return;
+    }
+
     notifier.fireTestStarted(this.description);
     try {
       this.block.run();
@@ -41,7 +48,12 @@ class Spec implements Child {
 
   @Override
   public void focus() {
+    if (this.ignored) return;
     this.parent.focus(this);
   }
 
+  @Override
+  public void ignore() {
+    ignored = true;
+  }
 }

--- a/src/main/java/com/greghaskins/spectrum/Spec.java
+++ b/src/main/java/com/greghaskins/spectrum/Spec.java
@@ -48,7 +48,10 @@ class Spec implements Child {
 
   @Override
   public void focus() {
-    if (this.ignored) return;
+    if (this.ignored) {
+      return;
+    }
+
     this.parent.focus(this);
   }
 

--- a/src/main/java/com/greghaskins/spectrum/Spectrum.java
+++ b/src/main/java/com/greghaskins/spectrum/Spectrum.java
@@ -14,7 +14,7 @@ public class Spectrum extends Runner {
    *
    */
   @FunctionalInterface
-  public static interface Block {
+  public interface Block {
 
     /**
      * Execute the code block, raising any {@code Throwable} that may occur.
@@ -54,6 +54,34 @@ public class Spectrum extends Runner {
   }
 
   /**
+   * Ignore the specific suite.
+   *
+   * @param context Description of the context for this suite
+   * @param block {@link Block} with one or more calls to {@link #it(String, Block) it} that define
+   *        each expected behavior
+   *
+   * @see #describe(String, Block)
+   *
+   */
+  public static void xdescribe(final String context, final Block block) {
+    final Suite suite = getCurrentSuite().addSuite(context);
+    suite.ignore();
+    beginDefintion(suite, block);
+  }
+
+  /**
+   * Ignore the specific suite.
+   *
+   * @param context Description of the context for this suite
+   *
+   * @see #describe(String, Block)
+   *
+   */
+  public static void xdescribe(final String context) {
+    xdescribe(context, () -> {});
+  }
+
+  /**
    * Declare a spec, or test, for an expected behavior of the system in this suite context.
    *
    * @param behavior Description of the expected behavior
@@ -75,6 +103,29 @@ public class Spectrum extends Runner {
    */
   public static void fit(final String behavior, final Block block) {
     getCurrentSuite().addSpec(behavior, block).focus();
+  }
+
+  /**
+   * Mark this specific spec as ignored.
+   *
+   * @param behavior Description of the expected behavior
+   * @param block {@link Block} that verifies the system behaves as expected, but won't be run.
+   *
+   * @see #it(String, Block)
+   */
+  public static void xit(final String behavior, final Block block) {
+    getCurrentSuite().addSpec(behavior, block).ignore();
+  }
+
+  /**
+   * Mark this specific spec as ignored.
+   *
+   * @param behavior Description of the expected behavior
+   *
+   * @see #it(String, Block)
+   */
+  public static void xit(final String behavior) {
+    xit(behavior, () -> {});
   }
 
   /**

--- a/src/main/java/com/greghaskins/spectrum/Spectrum.java
+++ b/src/main/java/com/greghaskins/spectrum/Spectrum.java
@@ -78,7 +78,8 @@ public class Spectrum extends Runner {
    *
    */
   public static void xdescribe(final String context) {
-    xdescribe(context, () -> {});
+    xdescribe(context, () -> {
+    });
   }
 
   /**
@@ -125,7 +126,8 @@ public class Spectrum extends Runner {
    * @see #it(String, Block)
    */
   public static void xit(final String behavior) {
-    xit(behavior, () -> {});
+    xit(behavior, () -> {
+    });
   }
 
   /**

--- a/src/main/java/com/greghaskins/spectrum/Suite.java
+++ b/src/main/java/com/greghaskins/spectrum/Suite.java
@@ -98,19 +98,22 @@ class Suite implements Parent, Child {
   }
 
   @Override
-  public boolean isIgnored() {
-    return this.ignored;
-  }
-
-  @Override
   public void focus() {
-    if (this.ignored) return;
+    if (this.ignored) {
+      return;
+    }
+
     this.parent.focus(this);
   }
 
   @Override
   public void ignore() {
     this.ignored = true;
+  }
+
+  @Override
+  public boolean isIgnored() {
+    return this.ignored;
   }
 
   @Override

--- a/src/main/java/com/greghaskins/spectrum/Suite.java
+++ b/src/main/java/com/greghaskins/spectrum/Suite.java
@@ -24,6 +24,7 @@ class Suite implements Parent, Child {
 
   private final Description description;
   private final Parent parent;
+  private boolean ignored;
 
   public static Suite rootSuite(final Description description) {
     return new Suite(description, Parent.NONE);
@@ -32,6 +33,7 @@ class Suite implements Parent, Child {
   private Suite(final Description description, final Parent parent) {
     this.description = description;
     this.parent = parent;
+    this.ignored = parent.isIgnored();
   }
 
   public Suite addSuite(final String name) {
@@ -96,8 +98,19 @@ class Suite implements Parent, Child {
   }
 
   @Override
+  public boolean isIgnored() {
+    return this.ignored;
+  }
+
+  @Override
   public void focus() {
+    if (this.ignored) return;
     this.parent.focus(this);
+  }
+
+  @Override
+  public void ignore() {
+    this.ignored = true;
   }
 
   @Override

--- a/src/test/java/specs/IgnoredSpecs.java
+++ b/src/test/java/specs/IgnoredSpecs.java
@@ -2,6 +2,7 @@ package specs;
 
 import static com.greghaskins.spectrum.Spectrum.beforeEach;
 import static com.greghaskins.spectrum.Spectrum.describe;
+import static com.greghaskins.spectrum.Spectrum.fdescribe;
 import static com.greghaskins.spectrum.Spectrum.fit;
 import static com.greghaskins.spectrum.Spectrum.it;
 import static com.greghaskins.spectrum.Spectrum.value;
@@ -62,13 +63,13 @@ public class IgnoredSpecs {
           assertThat(result.getIgnoreCount(), is(1));
         });
 
-        describe("and the nested suite has a focus", () -> {
+        describe("and the nested suite and spec have a focus", () -> {
           it("ignores the focus", () -> {
             final Result result =
                 SpectrumRunner.run(getSuiteWithNestedIgnoredSuitesAndFocusedSpecs());
             assertThat(result.getFailureCount(), is(0));
             assertThat(result.getRunCount(), is(1));
-            assertThat(result.getIgnoreCount(), is(1));
+            assertThat(result.getIgnoreCount(), is(2));
           });
         });
       });
@@ -176,7 +177,13 @@ public class IgnoredSpecs {
 
         xdescribe("a nested ignored context", () -> {
           describe("with a sub-suite", () -> {
-            fit("will not run forcued test", () -> {
+            fit("will not run focused test", () -> {
+              assertThat(true, is(false));
+            });
+          });
+
+          fdescribe("with focused sub-suite", () -> {
+            it("will not run regular test", () -> {
               assertThat(true, is(false));
             });
           });

--- a/src/test/java/specs/IgnoredSpecs.java
+++ b/src/test/java/specs/IgnoredSpecs.java
@@ -1,0 +1,241 @@
+package specs;
+
+import com.greghaskins.spectrum.Spectrum;
+import helpers.SpectrumRunner;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+
+import static com.greghaskins.spectrum.Spectrum.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(Spectrum.class)
+public class IgnoredSpecs {
+    {
+       describe("Ignored specs", () -> {
+           it("are declared with `xit`", () -> {
+               final Result result = SpectrumRunner.run(getSuiteWithIgnoredSpecs());
+               assertThat(result.getFailureCount(), is(0));
+           });
+
+           it("ignores tests that are xit", () -> {
+               final Result result = SpectrumRunner.run(getSuiteWithIgnoredSpecs());
+               assertThat(result.getRunCount(), is(1));
+               assertThat(result.getIgnoreCount(), is(2));
+           });
+
+           describe("with nesting", () -> {
+               it("ignores only the nested spec", () -> {
+                   final Result result = SpectrumRunner.run(getSuiteWithNestedIgnoredSpecs());
+                   assertThat(result.getFailureCount(), is(0));
+                   assertThat(result.getRunCount(), is(1));
+                   assertThat(result.getIgnoreCount(), is(1));
+               });
+           });
+       });
+
+        describe("Ignored suites", () -> {
+            it("are declared with `xdescribe`", () -> {
+                final Result result = SpectrumRunner.run(getSuiteWithIgnoredSubSuites());
+                assertThat(result.getFailureCount(), is(0));
+            });
+
+            it("ignores tests that are xdescribe", () -> {
+                final Result result = SpectrumRunner.run(getSuiteWithIgnoredSubSuites());
+                assertThat(result.getRunCount(), is(1));
+                assertThat(result.getIgnoreCount(), is(4));
+            });
+
+            describe("with nesting", () -> {
+                it("cause specs in other suites to also be ignored", () -> {
+                    final Result result = SpectrumRunner.run(getSuiteWithNestedIgnoredSuites());
+                    assertThat(result.getFailureCount(), is(0));
+                    assertThat(result.getRunCount(), is(1));
+                    assertThat(result.getIgnoreCount(), is(1));
+                });
+
+                describe("and the nested suite has a focus", () -> {
+                   it("ignores the focus", () -> {
+                       final Result result = SpectrumRunner.run(getSuiteWithNestedIgnoredSuitesAndFocusedSpecs());
+                       assertThat(result.getFailureCount(), is(0));
+                       assertThat(result.getRunCount(), is(1));
+                       assertThat(result.getIgnoreCount(), is(1));
+                   });
+                });
+            });
+        });
+
+        describe("Ignored specs example", () -> {
+            final Value<Result> result = value();
+
+            beforeEach(() -> {
+                result.value = SpectrumRunner.run(getIgnoredSpecsExample());
+            });
+
+            it("has three ignored specs", () -> {
+                assertThat(result.value.getIgnoreCount(), is(4));
+            });
+
+            it("does not run unfocused specs", () -> {
+                assertThat(result.value.getFailureCount(), is(0));
+            });
+        });
+    }
+
+    private static Class<?> getSuiteWithIgnoredSpecs() {
+        class Suite {
+            {
+
+                describe("A spec that", () -> {
+
+                    it("is not ignored and will run", () -> {
+                        assertThat(true, is(true));
+                    });
+
+                    xit("is ignored and will not run", () -> {
+                        assertThat(true, is(false));
+                    });
+
+                    xit("is ignored and has no block");
+                });
+            }
+        }
+
+        return Suite.class;
+    }
+
+    private static Class<?> getSuiteWithNestedIgnoredSpecs() {
+        class Suite {
+            {
+
+                it("should run because it isn't ignored", () -> {
+                    assertThat(true, is(true));
+                });
+
+                describe("a nested context", () -> {
+                    xit("is ignored and will not run", () -> {
+                        assertThat(true, is(false));
+                    });
+                });
+            }
+        }
+
+        return Suite.class;
+    }
+
+    private static Class<?> getSuiteWithIgnoredSubSuites() {
+        class Suite {
+            {
+                describe("an un-ignored suite", () -> {
+                    it("is not ignored", () -> {
+                        assertThat(true, is(true));
+                    });
+                });
+
+                xdescribe("ignored describe", () -> {
+                    it("will not run", () -> {
+                        assertThat(true, is(false));
+                    });
+
+                    it("will also not run", () -> {
+                        assertThat(true, is(false));
+                    });
+
+                    it("will also not run a focused test", () -> {
+                        assertThat(true, is(false));
+                    });
+                });
+
+                xdescribe("ignored describe with no block");
+            }
+        }
+
+        return Suite.class;
+    }
+
+    private static Class<?> getSuiteWithNestedIgnoredSuitesAndFocusedSpecs() {
+        class Suite {
+            {
+
+                describe("a nested context", () -> {
+                    describe("with a sub-suite", () -> {
+                        it("will run despite having a focused test", () -> {
+                            assertThat(true, is(true));
+                        });
+                    });
+                });
+
+                xdescribe("a nested ignored context", () -> {
+                    describe("with a sub-suite", () -> {
+                        fit("will not run forcued test", () -> {
+                            assertThat(true, is(false));
+                        });
+                    });
+                });
+            }
+        }
+
+        return Suite.class;
+    }
+
+    private static Class<?> getSuiteWithNestedIgnoredSuites() {
+        class Suite {
+            {
+
+                describe("a nested context", () -> {
+                    describe("with a sub-suite", () -> {
+                        it("will run", () -> {
+                            assertThat(true, is(true));
+                        });
+                    });
+                });
+
+                xdescribe("a nested ignored context", () -> {
+                    describe("with a sub-suite", () -> {
+                        it("will not run", () -> {
+                            assertThat(true, is(false));
+                        });
+                    });
+                });
+            }
+        }
+
+        return Suite.class;
+    }
+
+    private static Class<?> getIgnoredSpecsExample() {
+        class FocusedSpecsExample {
+            {
+                describe("Ignored specs", () -> {
+
+                    xit("is ignored and will not run", () -> {
+                        throw new Exception();
+                    });
+
+                    it("is not ignored and will run", () -> {
+                        assertThat(true, is(true));
+                    });
+
+                    xdescribe("an ignored suite", () -> {
+
+                        it("will not run", () -> {
+                            throw new Exception();
+                        });
+
+                        describe("with nesting", () -> {
+                            it("all its specs", () -> {
+                                throw new Exception();
+                            });
+
+                            fit("including focused specs", () -> {
+                                throw new Exception();
+                            });
+                        });
+                    });
+                });
+            }
+        }
+
+        return FocusedSpecsExample.class;
+    }
+}

--- a/src/test/java/specs/IgnoredSpecs.java
+++ b/src/test/java/specs/IgnoredSpecs.java
@@ -1,241 +1,250 @@
 package specs;
 
+import static com.greghaskins.spectrum.Spectrum.beforeEach;
+import static com.greghaskins.spectrum.Spectrum.describe;
+import static com.greghaskins.spectrum.Spectrum.fit;
+import static com.greghaskins.spectrum.Spectrum.it;
+import static com.greghaskins.spectrum.Spectrum.value;
+import static com.greghaskins.spectrum.Spectrum.xdescribe;
+import static com.greghaskins.spectrum.Spectrum.xit;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 import com.greghaskins.spectrum.Spectrum;
+import com.greghaskins.spectrum.Spectrum.Value;
+
 import helpers.SpectrumRunner;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
 
-import static com.greghaskins.spectrum.Spectrum.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
 @RunWith(Spectrum.class)
 public class IgnoredSpecs {
-    {
-       describe("Ignored specs", () -> {
-           it("are declared with `xit`", () -> {
-               final Result result = SpectrumRunner.run(getSuiteWithIgnoredSpecs());
-               assertThat(result.getFailureCount(), is(0));
-           });
+  {
+    describe("Ignored specs", () -> {
+      it("are declared with `xit`", () -> {
+        final Result result = SpectrumRunner.run(getSuiteWithIgnoredSpecs());
+        assertThat(result.getFailureCount(), is(0));
+      });
 
-           it("ignores tests that are xit", () -> {
-               final Result result = SpectrumRunner.run(getSuiteWithIgnoredSpecs());
-               assertThat(result.getRunCount(), is(1));
-               assertThat(result.getIgnoreCount(), is(2));
-           });
+      it("ignores tests that are xit", () -> {
+        final Result result = SpectrumRunner.run(getSuiteWithIgnoredSpecs());
+        assertThat(result.getRunCount(), is(1));
+        assertThat(result.getIgnoreCount(), is(2));
+      });
 
-           describe("with nesting", () -> {
-               it("ignores only the nested spec", () -> {
-                   final Result result = SpectrumRunner.run(getSuiteWithNestedIgnoredSpecs());
-                   assertThat(result.getFailureCount(), is(0));
-                   assertThat(result.getRunCount(), is(1));
-                   assertThat(result.getIgnoreCount(), is(1));
-               });
-           });
-       });
+      describe("with nesting", () -> {
+        it("ignores only the nested spec", () -> {
+          final Result result = SpectrumRunner.run(getSuiteWithNestedIgnoredSpecs());
+          assertThat(result.getFailureCount(), is(0));
+          assertThat(result.getRunCount(), is(1));
+          assertThat(result.getIgnoreCount(), is(1));
+        });
+      });
+    });
 
-        describe("Ignored suites", () -> {
-            it("are declared with `xdescribe`", () -> {
-                final Result result = SpectrumRunner.run(getSuiteWithIgnoredSubSuites());
-                assertThat(result.getFailureCount(), is(0));
+    describe("Ignored suites", () -> {
+      it("are declared with `xdescribe`", () -> {
+        final Result result = SpectrumRunner.run(getSuiteWithIgnoredSubSuites());
+        assertThat(result.getFailureCount(), is(0));
+      });
+
+      it("ignores tests that are xdescribe", () -> {
+        final Result result = SpectrumRunner.run(getSuiteWithIgnoredSubSuites());
+        assertThat(result.getRunCount(), is(1));
+        assertThat(result.getIgnoreCount(), is(4));
+      });
+
+      describe("with nesting", () -> {
+        it("cause specs in other suites to also be ignored", () -> {
+          final Result result = SpectrumRunner.run(getSuiteWithNestedIgnoredSuites());
+          assertThat(result.getFailureCount(), is(0));
+          assertThat(result.getRunCount(), is(1));
+          assertThat(result.getIgnoreCount(), is(1));
+        });
+
+        describe("and the nested suite has a focus", () -> {
+          it("ignores the focus", () -> {
+            final Result result =
+                SpectrumRunner.run(getSuiteWithNestedIgnoredSuitesAndFocusedSpecs());
+            assertThat(result.getFailureCount(), is(0));
+            assertThat(result.getRunCount(), is(1));
+            assertThat(result.getIgnoreCount(), is(1));
+          });
+        });
+      });
+    });
+
+    describe("Ignored specs example", () -> {
+      final Value<Result> result = value();
+
+      beforeEach(() -> {
+        result.value = SpectrumRunner.run(getIgnoredSpecsExample());
+      });
+
+      it("has three ignored specs", () -> {
+        assertThat(result.value.getIgnoreCount(), is(4));
+      });
+
+      it("does not run unfocused specs", () -> {
+        assertThat(result.value.getFailureCount(), is(0));
+      });
+    });
+  }
+
+  private static Class<?> getSuiteWithIgnoredSpecs() {
+    class Suite {
+      {
+
+        describe("A spec that", () -> {
+
+          it("is not ignored and will run", () -> {
+            assertThat(true, is(true));
+          });
+
+          xit("is ignored and will not run", () -> {
+            assertThat(true, is(false));
+          });
+
+          xit("is ignored and has no block");
+        });
+      }
+    }
+
+    return Suite.class;
+  }
+
+  private static Class<?> getSuiteWithNestedIgnoredSpecs() {
+    class Suite {
+      {
+
+        it("should run because it isn't ignored", () -> {
+          assertThat(true, is(true));
+        });
+
+        describe("a nested context", () -> {
+          xit("is ignored and will not run", () -> {
+            assertThat(true, is(false));
+          });
+        });
+      }
+    }
+
+    return Suite.class;
+  }
+
+  private static Class<?> getSuiteWithIgnoredSubSuites() {
+    class Suite {
+      {
+        describe("an un-ignored suite", () -> {
+          it("is not ignored", () -> {
+            assertThat(true, is(true));
+          });
+        });
+
+        xdescribe("ignored describe", () -> {
+          it("will not run", () -> {
+            assertThat(true, is(false));
+          });
+
+          it("will also not run", () -> {
+            assertThat(true, is(false));
+          });
+
+          it("will also not run a focused test", () -> {
+            assertThat(true, is(false));
+          });
+        });
+
+        xdescribe("ignored describe with no block");
+      }
+    }
+
+    return Suite.class;
+  }
+
+  private static Class<?> getSuiteWithNestedIgnoredSuitesAndFocusedSpecs() {
+    class Suite {
+      {
+
+        describe("a nested context", () -> {
+          describe("with a sub-suite", () -> {
+            it("will run despite having a focused test", () -> {
+              assertThat(true, is(true));
             });
+          });
+        });
 
-            it("ignores tests that are xdescribe", () -> {
-                final Result result = SpectrumRunner.run(getSuiteWithIgnoredSubSuites());
-                assertThat(result.getRunCount(), is(1));
-                assertThat(result.getIgnoreCount(), is(4));
+        xdescribe("a nested ignored context", () -> {
+          describe("with a sub-suite", () -> {
+            fit("will not run forcued test", () -> {
+              assertThat(true, is(false));
+            });
+          });
+        });
+      }
+    }
+
+    return Suite.class;
+  }
+
+  private static Class<?> getSuiteWithNestedIgnoredSuites() {
+    class Suite {
+      {
+
+        describe("a nested context", () -> {
+          describe("with a sub-suite", () -> {
+            it("will run", () -> {
+              assertThat(true, is(true));
+            });
+          });
+        });
+
+        xdescribe("a nested ignored context", () -> {
+          describe("with a sub-suite", () -> {
+            it("will not run", () -> {
+              assertThat(true, is(false));
+            });
+          });
+        });
+      }
+    }
+
+    return Suite.class;
+  }
+
+  private static Class<?> getIgnoredSpecsExample() {
+    class FocusedSpecsExample {
+      {
+        describe("Ignored specs", () -> {
+
+          xit("is ignored and will not run", () -> {
+            throw new Exception();
+          });
+
+          it("is not ignored and will run", () -> {
+            assertThat(true, is(true));
+          });
+
+          xdescribe("an ignored suite", () -> {
+
+            it("will not run", () -> {
+              throw new Exception();
             });
 
             describe("with nesting", () -> {
-                it("cause specs in other suites to also be ignored", () -> {
-                    final Result result = SpectrumRunner.run(getSuiteWithNestedIgnoredSuites());
-                    assertThat(result.getFailureCount(), is(0));
-                    assertThat(result.getRunCount(), is(1));
-                    assertThat(result.getIgnoreCount(), is(1));
-                });
+              it("all its specs", () -> {
+                throw new Exception();
+              });
 
-                describe("and the nested suite has a focus", () -> {
-                   it("ignores the focus", () -> {
-                       final Result result = SpectrumRunner.run(getSuiteWithNestedIgnoredSuitesAndFocusedSpecs());
-                       assertThat(result.getFailureCount(), is(0));
-                       assertThat(result.getRunCount(), is(1));
-                       assertThat(result.getIgnoreCount(), is(1));
-                   });
-                });
+              fit("including focused specs", () -> {
+                throw new Exception();
+              });
             });
+          });
         });
-
-        describe("Ignored specs example", () -> {
-            final Value<Result> result = value();
-
-            beforeEach(() -> {
-                result.value = SpectrumRunner.run(getIgnoredSpecsExample());
-            });
-
-            it("has three ignored specs", () -> {
-                assertThat(result.value.getIgnoreCount(), is(4));
-            });
-
-            it("does not run unfocused specs", () -> {
-                assertThat(result.value.getFailureCount(), is(0));
-            });
-        });
+      }
     }
 
-    private static Class<?> getSuiteWithIgnoredSpecs() {
-        class Suite {
-            {
-
-                describe("A spec that", () -> {
-
-                    it("is not ignored and will run", () -> {
-                        assertThat(true, is(true));
-                    });
-
-                    xit("is ignored and will not run", () -> {
-                        assertThat(true, is(false));
-                    });
-
-                    xit("is ignored and has no block");
-                });
-            }
-        }
-
-        return Suite.class;
-    }
-
-    private static Class<?> getSuiteWithNestedIgnoredSpecs() {
-        class Suite {
-            {
-
-                it("should run because it isn't ignored", () -> {
-                    assertThat(true, is(true));
-                });
-
-                describe("a nested context", () -> {
-                    xit("is ignored and will not run", () -> {
-                        assertThat(true, is(false));
-                    });
-                });
-            }
-        }
-
-        return Suite.class;
-    }
-
-    private static Class<?> getSuiteWithIgnoredSubSuites() {
-        class Suite {
-            {
-                describe("an un-ignored suite", () -> {
-                    it("is not ignored", () -> {
-                        assertThat(true, is(true));
-                    });
-                });
-
-                xdescribe("ignored describe", () -> {
-                    it("will not run", () -> {
-                        assertThat(true, is(false));
-                    });
-
-                    it("will also not run", () -> {
-                        assertThat(true, is(false));
-                    });
-
-                    it("will also not run a focused test", () -> {
-                        assertThat(true, is(false));
-                    });
-                });
-
-                xdescribe("ignored describe with no block");
-            }
-        }
-
-        return Suite.class;
-    }
-
-    private static Class<?> getSuiteWithNestedIgnoredSuitesAndFocusedSpecs() {
-        class Suite {
-            {
-
-                describe("a nested context", () -> {
-                    describe("with a sub-suite", () -> {
-                        it("will run despite having a focused test", () -> {
-                            assertThat(true, is(true));
-                        });
-                    });
-                });
-
-                xdescribe("a nested ignored context", () -> {
-                    describe("with a sub-suite", () -> {
-                        fit("will not run forcued test", () -> {
-                            assertThat(true, is(false));
-                        });
-                    });
-                });
-            }
-        }
-
-        return Suite.class;
-    }
-
-    private static Class<?> getSuiteWithNestedIgnoredSuites() {
-        class Suite {
-            {
-
-                describe("a nested context", () -> {
-                    describe("with a sub-suite", () -> {
-                        it("will run", () -> {
-                            assertThat(true, is(true));
-                        });
-                    });
-                });
-
-                xdescribe("a nested ignored context", () -> {
-                    describe("with a sub-suite", () -> {
-                        it("will not run", () -> {
-                            assertThat(true, is(false));
-                        });
-                    });
-                });
-            }
-        }
-
-        return Suite.class;
-    }
-
-    private static Class<?> getIgnoredSpecsExample() {
-        class FocusedSpecsExample {
-            {
-                describe("Ignored specs", () -> {
-
-                    xit("is ignored and will not run", () -> {
-                        throw new Exception();
-                    });
-
-                    it("is not ignored and will run", () -> {
-                        assertThat(true, is(true));
-                    });
-
-                    xdescribe("an ignored suite", () -> {
-
-                        it("will not run", () -> {
-                            throw new Exception();
-                        });
-
-                        describe("with nesting", () -> {
-                            it("all its specs", () -> {
-                                throw new Exception();
-                            });
-
-                            fit("including focused specs", () -> {
-                                throw new Exception();
-                            });
-                        });
-                    });
-                });
-            }
-        }
-
-        return FocusedSpecsExample.class;
-    }
+    return FocusedSpecsExample.class;
+  }
 }


### PR DESCRIPTION
Resolves #5 and #6. 