### PR TITLE
Add a `let` helper method similar to RSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,35 @@ describe("Ignored specs", () -> {
 });
 ```
 
+### Shared Variables Across Specs
+
+The `let` helper function makes it easier to initialize common variables that are used in multiple specs. This also helps work around Java's restriction that closures can only reference `final` variables in the containing scope. Values are cached within a spec, and lazily re-initialized between specs as in [RSpec #let](http://rspec.info/documentation/3.5/rspec-core/RSpec/Core/MemoizedHelpers/ClassMethods.html#let-instance_method).
+
+> from [LetSpecs.java](src/test/java/specs/LetSpecs.java)
+
+```java
+describe("The `let` helper function", () -> {
+
+  final Supplier<List<String>> items = let(() -> new ArrayList<>(asList("foo", "bar")));
+
+  it("is a way to supply a value for specs", () -> {
+    assertThat(items.get(), contains("foo", "bar"));
+  });
+
+  it("caches the value so it doesn't get created multiple times for the same spec", () -> {
+    assertThat(items.get(), is(sameInstance(items.get())));
+
+    items.get().add("baz");
+    items.get().add("blah");
+    assertThat(items.get(), contains("foo", "bar", "baz", "blah"));
+  });
+
+  it("creates a fresh value for every spec", () -> {
+    assertThat(items.get(), contains("foo", "bar"));
+  });
+});
+```
+
 ## Supported Features
 
 Spectrum moving toward a `1.0` release with close alignment to Jasmine's test declaration API. The library already supports a nice subset of those features:

--- a/README.md
+++ b/README.md
@@ -235,9 +235,9 @@ describe("Ignored specs", () -> {
 });
 ```
 
-### Shared Variables Across Specs
+### Common Variable Initialization
 
-The `let` helper function makes it easier to initialize common variables that are used in multiple specs. This also helps work around Java's restriction that closures can only reference `final` variables in the containing scope. Values are cached within a spec, and lazily re-initialized between specs as in [RSpec #let](http://rspec.info/documentation/3.5/rspec-core/RSpec/Core/MemoizedHelpers/ClassMethods.html#let-instance_method).
+The `let` helper function makes it easy to initialize common variables that are used in multiple specs. This also helps work around Java's restriction that closures can only reference `final` variables in the containing scope. Values are cached within a spec, and lazily re-initialized between specs as in [RSpec #let](http://rspec.info/documentation/3.5/rspec-core/RSpec/Core/MemoizedHelpers/ClassMethods.html#let-instance_method).
 
 > from [LetSpecs.java](src/test/java/specs/LetSpecs.java)
 

--- a/src/main/java/com/greghaskins/spectrum/Spectrum.java
+++ b/src/main/java/com/greghaskins/spectrum/Spectrum.java
@@ -6,6 +6,8 @@ import org.junit.runner.notification.RunNotifier;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 public class Spectrum extends Runner {
 
@@ -172,7 +174,26 @@ public class Spectrum extends Runner {
     getCurrentSuite().afterAll(block);
   }
 
+  /**
+   * Define a memoized helper function. The value will be cached across multiple calls in the same
+   * spec, but not across specs.
+   *
+   * <p>
+   * Note that {@code let} is lazy-evaluated: the {@code supplier} is not called until the first
+   * time it is used.
+   * </p>
+   *
+   * @param <T> The type of value
+   *
+   * @param supplier Function that generates the value
+   * @return memoized supplier
+   */
+  public static <T> Supplier<T> let(final Supplier<T> supplier) {
+    final ConcurrentHashMap<Supplier<T>, T> cache = new ConcurrentHashMap<>(1);
+    afterEach(() -> cache.clear());
 
+    return () -> cache.computeIfAbsent(supplier, s -> s.get());
+  }
 
   /**
    * Create a new Value wrapper. This is just a pointer to an instance of type <tt>T</tt>, which is

--- a/src/main/java/com/greghaskins/spectrum/Spectrum.java
+++ b/src/main/java/com/greghaskins/spectrum/Spectrum.java
@@ -192,7 +192,13 @@ public class Spectrum extends Runner {
     final ConcurrentHashMap<Supplier<T>, T> cache = new ConcurrentHashMap<>(1);
     afterEach(() -> cache.clear());
 
-    return () -> cache.computeIfAbsent(supplier, s -> s.get());
+    return () -> {
+      if (getCurrentSuite() == null) {
+        return cache.computeIfAbsent(supplier, s -> s.get());
+      }
+      throw new IllegalStateException("Cannot use the value from let() in a suite declaration. "
+          + "It may only be used in the context of a running spec.");
+    };
   }
 
   /**

--- a/src/main/java/com/greghaskins/spectrum/Spectrum.java
+++ b/src/main/java/com/greghaskins/spectrum/Spectrum.java
@@ -35,7 +35,7 @@ public class Spectrum extends Runner {
    *
    */
   public static void describe(final String context, final Block block) {
-    final Suite suite = getCurrentSuite().addSuite(context);
+    final Suite suite = getCurrentSuiteBeingDeclared().addSuite(context);
     beginDefintion(suite, block);
   }
 
@@ -50,7 +50,7 @@ public class Spectrum extends Runner {
    *
    */
   public static void fdescribe(final String context, final Block block) {
-    final Suite suite = getCurrentSuite().addSuite(context);
+    final Suite suite = getCurrentSuiteBeingDeclared().addSuite(context);
     suite.focus();
     beginDefintion(suite, block);
   }
@@ -66,7 +66,7 @@ public class Spectrum extends Runner {
    *
    */
   public static void xdescribe(final String context, final Block block) {
-    final Suite suite = getCurrentSuite().addSuite(context);
+    final Suite suite = getCurrentSuiteBeingDeclared().addSuite(context);
     suite.ignore();
     beginDefintion(suite, block);
   }
@@ -79,7 +79,7 @@ public class Spectrum extends Runner {
    *        {@link java.lang.Throwable Throwable} if that expectation is not met.
    */
   public static void it(final String behavior, final Block block) {
-    getCurrentSuite().addSpec(behavior, block);
+    getCurrentSuiteBeingDeclared().addSpec(behavior, block);
   }
 
   /**
@@ -90,7 +90,7 @@ public class Spectrum extends Runner {
    * @see #xit(String, Block)
    */
   public static void it(final String behavior) {
-    getCurrentSuite().addSpec(behavior, null).ignore();
+    getCurrentSuiteBeingDeclared().addSpec(behavior, null).ignore();
   }
 
   /**
@@ -103,7 +103,7 @@ public class Spectrum extends Runner {
    * @see #it(String, Block)
    */
   public static void fit(final String behavior, final Block block) {
-    getCurrentSuite().addSpec(behavior, block).focus();
+    getCurrentSuiteBeingDeclared().addSpec(behavior, block).focus();
   }
 
   /**
@@ -129,7 +129,7 @@ public class Spectrum extends Runner {
    * @param block {@link Block} to run once before each spec
    */
   public static void beforeEach(final Block block) {
-    getCurrentSuite().beforeEach(block);
+    getCurrentSuiteBeingDeclared().beforeEach(block);
   }
 
   /**
@@ -143,7 +143,7 @@ public class Spectrum extends Runner {
    * @param block {@link Block} to run once after each spec
    */
   public static void afterEach(final Block block) {
-    getCurrentSuite().afterEach(block);
+    getCurrentSuiteBeingDeclared().afterEach(block);
   }
 
   /**
@@ -157,7 +157,7 @@ public class Spectrum extends Runner {
    * @param block {@link Block} to run once before all specs in this suite
    */
   public static void beforeAll(final Block block) {
-    getCurrentSuite().beforeAll(block);
+    getCurrentSuiteBeingDeclared().beforeAll(block);
   }
 
   /**
@@ -171,7 +171,7 @@ public class Spectrum extends Runner {
    * @param block {@link Block} to run once after all specs in this suite
    */
   public static void afterAll(final Block block) {
-    getCurrentSuite().afterAll(block);
+    getCurrentSuiteBeingDeclared().afterAll(block);
   }
 
   /**
@@ -193,7 +193,7 @@ public class Spectrum extends Runner {
     afterEach(() -> cache.clear());
 
     return () -> {
-      if (getCurrentSuite() == null) {
+      if (getCurrentSuiteBeingDeclared() == null) {
         return cache.computeIfAbsent(supplier, s -> s.get());
       }
       throw new IllegalStateException("Cannot use the value from let() in a suite declaration. "
@@ -288,7 +288,7 @@ public class Spectrum extends Runner {
     suiteStack.pop();
   }
 
-  private static synchronized Suite getCurrentSuite() {
+  private static synchronized Suite getCurrentSuiteBeingDeclared() {
     return suiteStack.peek();
   }
 

--- a/src/test/java/specs/LetSpecs.java
+++ b/src/test/java/specs/LetSpecs.java
@@ -22,21 +22,22 @@ public class LetSpecs {
   {
     describe("The `let` helper function", () -> {
 
-      final Supplier<List<String>> words = let(() -> new ArrayList<>(asList("foo", "bar")));
+      final Supplier<List<String>> items = let(() -> new ArrayList<>(asList("foo", "bar")));
 
       it("is a way to supply a value for specs", () -> {
-        assertThat(words.get(), contains("foo", "bar"));
+        assertThat(items.get(), contains("foo", "bar"));
       });
 
-      it("caches the value so it doesn't get created multiple times", () -> {
-        words.get().add("baz");
-        words.get().add("blah");
-        assertThat(words.get(), is(sameInstance(words.get())));
-        assertThat(words.get(), contains("foo", "bar", "baz", "blah"));
+      it("caches the value so it doesn't get created multiple times for the same spec", () -> {
+        assertThat(items.get(), is(sameInstance(items.get())));
+
+        items.get().add("baz");
+        items.get().add("blah");
+        assertThat(items.get(), contains("foo", "bar", "baz", "blah"));
       });
 
       it("creates a fresh value for every spec", () -> {
-        assertThat(words.get(), contains("foo", "bar"));
+        assertThat(items.get(), contains("foo", "bar"));
       });
     });
   }

--- a/src/test/java/specs/LetSpecs.java
+++ b/src/test/java/specs/LetSpecs.java
@@ -1,0 +1,43 @@
+package specs;
+
+import static com.greghaskins.spectrum.Spectrum.describe;
+import static com.greghaskins.spectrum.Spectrum.it;
+import static com.greghaskins.spectrum.Spectrum.let;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+import com.greghaskins.spectrum.Spectrum;
+
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+@RunWith(Spectrum.class)
+public class LetSpecs {
+  {
+    describe("The `let` helper function", () -> {
+
+      final Supplier<List<String>> words = let(() -> new ArrayList<>(asList("foo", "bar")));
+
+      it("is a way to supply a value for specs", () -> {
+        assertThat(words.get(), contains("foo", "bar"));
+      });
+
+      it("caches the value so it doesn't get created multiple times", () -> {
+        words.get().add("baz");
+        words.get().add("blah");
+        assertThat(words.get(), is(sameInstance(words.get())));
+        assertThat(words.get(), contains("foo", "bar", "baz", "blah"));
+      });
+
+      it("creates a fresh value for every spec", () -> {
+        assertThat(words.get(), contains("foo", "bar"));
+      });
+    });
+  }
+}


### PR DESCRIPTION
See the [RSpec examples](https://www.relishapp.com/rspec/rspec-core/v/3-5/docs/helper-methods/let-and-let) and [API docs](http://rspec.info/documentation/3.5/rspec-core/RSpec/Core/MemoizedHelpers/ClassMethods.html#let-instance_method).

This PR creates a `let` helper that makes it simpler to declare values/variables used by specs. The semantics are the same as the standard RSpec `let`.

I think this will be useful for initializing values like mocks without having to declare elaborate `beforeEach` and `afterEach` blocks:

```java
describe("A widget", () -> {
  final Supplier<Thing> thing = let(() -> mock(Thing.class));
  final Supplier<Widget> widget = let(() -> new Widget(thing.get());

  it("should have its thing", () -> {
    assertThat(widget.get().thing(), is(thing.get());
  });

  it("should have the thing do stuff when it runs", () -> {
    widget.get().run();
    verify(thing.get()).doStuff();
  });
});
```

For another example, see [LetSpecs.java](https://github.com/greghaskins/spectrum/blob/rspec-style-let/src/test/java/specs/LetSpecs.java).

Some notes/thoughts:
- This uses the standard Java 8 [`Supplier`](https://docs.oracle.com/javase/8/docs/api/java/util/function/Supplier.html) interface, hence the calls to `get()`.
- It does _not_ include the eager variant (`let!` in RSpec) that always evaluates suppliers in `beforeEach`. I don't know how useful that is in practice; perhaps it could be added later.
- I think this is a better design than the `Value` wrapper I made up. It is more consistent with existing APIs, is more flexible, and has a simpler implementation. We should consider possibly removing the `value()` API and use `let()` instead for `v1.0.0`.
- I still need to update the README to include this feature, but I'll wait to see if there's major disagreement before doing so.

Comments?