### PR TITLE
Bug fix: make sure specs don't run if suite has declaration error

### DIFF
--- a/src/main/java/com/greghaskins/spectrum/Spectrum.java
+++ b/src/main/java/com/greghaskins/spectrum/Spectrum.java
@@ -254,6 +254,7 @@ public class Spectrum extends Runner {
     try {
       definitionBlock.run();
     } catch (final Throwable error) {
+      suite.removeAllChildren();
       it("encountered an error", () -> {
         throw error;
       });

--- a/src/main/java/com/greghaskins/spectrum/Suite.java
+++ b/src/main/java/com/greghaskins/spectrum/Suite.java
@@ -142,10 +142,7 @@ class Suite implements Parent, Child {
     try {
       this.afterAll.run();
     } catch (final Throwable error) {
-      final Description failureDescription =
-          Description.createTestDescription(this.description.getClassName(), "error in afterAll");
-      this.description.addChild(failureDescription);
-      notifier.fireTestFailure(new Failure(failureDescription, error));
+      notifier.fireTestFailure(new Failure(this.description, error));
     }
   }
 

--- a/src/main/java/com/greghaskins/spectrum/Suite.java
+++ b/src/main/java/com/greghaskins/spectrum/Suite.java
@@ -71,7 +71,6 @@ class Suite implements Parent, Child {
   }
 
   private void addChild(final Child child) {
-    this.description.addChild(child.getDescription());
     this.children.add(child);
   }
 
@@ -152,12 +151,19 @@ class Suite implements Parent, Child {
 
   @Override
   public Description getDescription() {
-    return this.description;
+    final Description copy = this.description.childlessCopy();
+    this.children.stream().forEach((child) -> copy.addChild(child.getDescription()));
+
+    return copy;
   }
 
   @Override
   public int testCount() {
     return this.children.stream().mapToInt((child) -> child.testCount()).sum();
+  }
+
+  public void removeAllChildren() {
+    this.children.clear();
   }
 
 }

--- a/src/test/java/given/a/spec/with/exception/in/describe/block/Fixture.java
+++ b/src/test/java/given/a/spec/with/exception/in/describe/block/Fixture.java
@@ -1,14 +1,27 @@
 package given.a.spec.with.exception.in.describe.block;
 
 import static com.greghaskins.spectrum.Spectrum.describe;
+import static com.greghaskins.spectrum.Spectrum.it;
 
 class Fixture {
 
   public static Class<?> getSpecThatThrowsAnExceptionInDescribeBlock() {
+    @SuppressWarnings("unused")
     class Spec {
       {
         describe("an exploding context", () -> {
-          throw new SomeException("kaboom");
+
+          it("should not run", () -> {
+            throw new Exception();
+          });
+
+          if (true) {
+            throw new SomeException("kaboom");
+          }
+
+          it("also should not run", () -> {
+            throw new Exception();
+          });
         });
       }
     }

--- a/src/test/java/given/a/spec/with/exception/in/describe/block/WhenRunningTheSpec.java
+++ b/src/test/java/given/a/spec/with/exception/in/describe/block/WhenRunningTheSpec.java
@@ -19,7 +19,7 @@ public class WhenRunningTheSpec {
   }
 
   @Test
-  public void thereIsOneFailure() throws Exception {
+  public void thereIsOneAndOnlyOneFailure() throws Exception {
     assertThat(this.result.getFailureCount(), is(1));
   }
 

--- a/src/test/java/specs/FixturesSpec.java
+++ b/src/test/java/specs/FixturesSpec.java
@@ -13,6 +13,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.greghaskins.spectrum.Spectrum;
 import com.greghaskins.spectrum.Spectrum.Block;
@@ -247,6 +248,7 @@ public class FixturesSpec {
         final Result result = SpectrumRunner.run(getSpecWithExplodingAfterAll());
         final Failure failure = result.getFailures().get(0);
         assertThat(failure.getDescription().getClassName(), is("Exploding afterAll"));
+        assertThat(failure.getDescription().getMethodName(), is(nullValue()));
       });
 
       it("have a failure on the first exception", () -> {


### PR DESCRIPTION
If an error occurred in a suite declaration _after_ some specs had been declared, those specs would still run.

This PR makes sure no specs are run from any suite that doesn't complete its declaration block.