### PR TITLE
Let consistency with hooks

### DIFF
--- a/src/main/java/com/greghaskins/spectrum/Spectrum.java
+++ b/src/main/java/com/greghaskins/spectrum/Spectrum.java
@@ -325,7 +325,7 @@ public final class Spectrum extends Runner {
   public static <T> Supplier<T> let(final com.greghaskins.spectrum.ThrowingSupplier<T> supplier) {
     LetHook<T> letHook = new LetHook<>(supplier);
     HookContext hookContext = new HookContext(letHook, getDepth(),
-        HookContext.AppliesTo.EACH_CHILD, HookContext.Precedence.LOCAL);
+        HookContext.AppliesTo.ATOMIC_ONLY, HookContext.Precedence.LOCAL);
     addHook(hookContext);
 
     return letHook;

--- a/src/test/java/specs/LetSpecs.java
+++ b/src/test/java/specs/LetSpecs.java
@@ -51,42 +51,42 @@ public class LetSpecs {
       describe("in complex test hierarchies", () -> {
         describe("a new let object is created for each spec", () -> {
           AtomicInteger integer = new AtomicInteger();
-              describe("a thing", () -> {
+          describe("a thing", () -> {
 
-              final Supplier<Integer> intLet = let(integer::getAndIncrement);
+            final Supplier<Integer> intLet = let(integer::getAndIncrement);
 
-              it("starts with one value", () -> {
-                assertThat(intLet.get(), is(0));
+            it("starts with one value", () -> {
+              assertThat(intLet.get(), is(0));
 
-                // still the same inside this test
-                assertThat(intLet.get(), is(0));
-              });
+              // still the same inside this test
+              assertThat(intLet.get(), is(0));
+            });
 
-              it("gets a second", () -> {
-                assertThat(intLet.get(), is(1));
+            it("gets a second", () -> {
+              assertThat(intLet.get(), is(1));
+            });
+
+            it("and another", () -> {
+              assertThat(intLet.get(), is(2));
+            });
+
+            describe("a sub suite", () -> {
+              it("gets another", () -> {
+                assertThat(intLet.get(), is(3));
               });
 
               it("and another", () -> {
-                assertThat(intLet.get(), is(2));
+                assertThat(intLet.get(), is(4));
               });
 
-              describe("a sub suite", () -> {
+              describe("and a sub suite of that", () -> {
                 it("gets another", () -> {
-                  assertThat(intLet.get(), is(3));
-                });
-
-                it("and another", () -> {
-                  assertThat(intLet.get(), is(4));
-                });
-
-                describe("and a sub suite of that", () -> {
-                  it("gets another", () -> {
-                    assertThat(intLet.get(), is(5));
-                  });
+                  assertThat(intLet.get(), is(5));
                 });
               });
-
             });
+
+          });
 
         });
       });

--- a/src/test/java/specs/LetSpecs.java
+++ b/src/test/java/specs/LetSpecs.java
@@ -22,6 +22,7 @@ import org.junit.runner.notification.Failure;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 @RunWith(Spectrum.class)
@@ -45,6 +46,49 @@ public class LetSpecs {
 
       it("creates a fresh value for every spec", () -> {
         assertThat(items.get(), contains("foo", "bar"));
+      });
+
+      describe("in complex test hierarchies", () -> {
+        describe("a new let object is created for each spec", () -> {
+          AtomicInteger integer = new AtomicInteger();
+              describe("a thing", () -> {
+
+              final Supplier<Integer> intLet = let(integer::getAndIncrement);
+
+              it("starts with one value", () -> {
+                assertThat(intLet.get(), is(0));
+
+                // still the same inside this test
+                assertThat(intLet.get(), is(0));
+              });
+
+              it("gets a second", () -> {
+                assertThat(intLet.get(), is(1));
+              });
+
+              it("and another", () -> {
+                assertThat(intLet.get(), is(2));
+              });
+
+              describe("a sub suite", () -> {
+                it("gets another", () -> {
+                  assertThat(intLet.get(), is(3));
+                });
+
+                it("and another", () -> {
+                  assertThat(intLet.get(), is(4));
+                });
+
+                describe("and a sub suite of that", () -> {
+                  it("gets another", () -> {
+                    assertThat(intLet.get(), is(5));
+                  });
+                });
+              });
+
+            });
+
+        });
       });
 
       describe("when trying to use a value outside a spec", () -> {
@@ -313,5 +357,4 @@ public class LetSpecs {
 
     return Suite.class;
   }
-
 }


### PR DESCRIPTION
A fix for a minor error in the switch of `let` from its original implementation to the new hook-based implementation. `let` should run afresh for every atomic spec.

Additional tests created on the release version of Spectrum and then applied to the hook version and made to go green.