### PR TITLE
Switch from coveralls.io to codecov.io

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  range: 90..100
+  round: down
+  precision: 2
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+        base: auto
+    patch:
+      default:
+        target: 100%
+        threshold: 0%
+        base: auto

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,3 +13,7 @@ coverage:
         target: 100%
         threshold: 0%
         base: auto
+comment:
+  layout: "header, diff, tree"
+  behavior: once
+  require_changes: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   - echo "Checking to make sure all changes are checked in..."
   - test -z "$(git status --porcelain)"
 after_success:
-  - " ./gradlew coveralls"
+  - "bash <(curl -s https://codecov.io/bash)"
 deploy:
   provider: script
   script: "./gradlew bintrayUpload"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Spectrum
 ========
 
-[![Build Status](https://img.shields.io/travis/greghaskins/spectrum.svg)](https://travis-ci.org/greghaskins/spectrum) [![Coverage Status](https://img.shields.io/coveralls/greghaskins/spectrum.svg)](https://coveralls.io/r/greghaskins/spectrum) [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Download](https://api.bintray.com/packages/greghaskins/maven/Spectrum/images/download.svg) ](https://bintray.com/greghaskins/maven/Spectrum/_latestVersion) [![Gitter](https://img.shields.io/gitter/room/greghaskins/spectrum.svg)](https://gitter.im/greghaskins/spectrum)
+[![Build Status](https://img.shields.io/travis/greghaskins/spectrum.svg)](https://travis-ci.org/greghaskins/spectrum) [![Codecov](https://img.shields.io/codecov/c/github/greghaskins/spectrum.svg)](https://codecov.io/gh/greghaskins/spectrum) [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Download](https://api.bintray.com/packages/greghaskins/maven/Spectrum/images/download.svg) ](https://bintray.com/greghaskins/maven/Spectrum/_latestVersion) [![Gitter](https://img.shields.io/gitter/room/greghaskins/spectrum.svg)](https://gitter.im/greghaskins/spectrum)
 
 *A colorful BDD-style test runner for Java*
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id "com.cinnober.gradle.semver-git" version "2.2.2"
-  id "com.github.kt3k.coveralls" version "2.4.0x"
   id "com.jfrog.bintray" version "1.3.1"
   id "com.diffplug.gradle.spotless" version "1.3.3"
 }


### PR DESCRIPTION
All lines of each patch should be covered, and overall coverage should
not decrease.