### PR TITLE
Add missing SCM metadata for Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,11 @@ def pomConfig = {
             organizationUrl 'https://github.com/spectrumbdd/'
         }
     }
+    scm {
+      connection 'scm:git:https://github.com/greghaskins/spectrum.git'
+      developerConnection 'scm:git:ssh://github.com:greghaskins/spectrum.git'
+      url 'https://github.com/greghaskins/spectrum/tree/master'
+    }
 }
 
 def description = 'A colorful BDD-style test runner for Java'

--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,7 @@ bintray {
   user = System.getenv('BINTRAY_USER')
   key = System.getenv('BINTRAY_KEY')
   publish = true
-  dryRun = true
+  dryRun = System.getenv("CI") == null
   publications = ['bintrayPublication']
   pkg {
     repo = 'maven'


### PR DESCRIPTION
I did this on a separate tag for `1.0.2`, applying again for `master`.