### PR TITLE
Modified `BlockConfigurationChain` to use typed objects 

### DIFF
--- a/src/main/java/com/greghaskins/spectrum/BlockConfigurationChain.java
+++ b/src/main/java/com/greghaskins/spectrum/BlockConfigurationChain.java
@@ -1,37 +1,52 @@
 package com.greghaskins.spectrum;
 
+import com.greghaskins.spectrum.internal.BlockConfigurable;
 import com.greghaskins.spectrum.internal.BlockConfiguration;
 
+import java.util.stream.Stream;
+
+/**
+ * Chainable configuration of a {@link com.greghaskins.spectrum.internal.ConfiguredBlock}.
+ * Use the factory methods in {@link Spectrum} like {@link Spectrum#ignore()},
+ * {@link Spectrum#focus()} or {@link Spectrum#tags(String...)} to add configuration
+ * to a block. The result will be a {@link BlockConfigurationChain}. To add configurations together
+ * you use {@link BlockConfigurationChain#and(BlockConfigurationChain)}. This is fluent
+ * so ands can be chained together.<br><br>
+ * e.g.<pre>with(ignore().and(tags("a","b","c")).and(tags("d","e","f"), () -&gt; {...})</pre><br>
+ * See also: {@link Spectrum#with(BlockConfigurationChain, Block)}
+ */
 public class BlockConfigurationChain {
 
   private BlockConfiguration blockConfiguration = BlockConfiguration.defaultConfiguration();
 
-  public BlockConfigurationChain ignore() {
-    this.blockConfiguration.ignore();
+  /**
+   * Fluent call to add a configurable to the configuration.
+   * @param configurable to add.
+   * @return this for fluent calling - users will use {@link #and(BlockConfigurationChain)}
+   */
+  BlockConfigurationChain with(BlockConfigurable<?> configurable) {
+    blockConfiguration.add(configurable);
 
     return this;
   }
 
-  public BlockConfigurationChain ignore(@SuppressWarnings("unused") String reason) {
-    this.blockConfiguration.ignore();
-
-    return this;
-  }
-
-  public BlockConfigurationChain focus() {
-    this.blockConfiguration.focus();
-
-    return this;
-  }
-
-  public BlockConfigurationChain tags(String... tags) {
-    this.blockConfiguration.tags(tags);
+  /**
+   * Add another configuration to the chain.
+   * @param chain the configurable to add.
+   * @return this for fluent calls
+   */
+  public BlockConfigurationChain and(BlockConfigurationChain chain) {
+    chain.getConfigurables().forEach(this::with);
 
     return this;
   }
 
   BlockConfiguration getBlockConfiguration() {
     return this.blockConfiguration;
+  }
+
+  private Stream<BlockConfigurable<?>> getConfigurables() {
+    return this.blockConfiguration.getConfigurables();
   }
 
 }

--- a/src/main/java/com/greghaskins/spectrum/Spectrum.java
+++ b/src/main/java/com/greghaskins/spectrum/Spectrum.java
@@ -3,6 +3,9 @@ package com.greghaskins.spectrum;
 import static com.greghaskins.spectrum.internal.hooks.AfterHook.after;
 import static com.greghaskins.spectrum.internal.hooks.BeforeHook.before;
 
+import com.greghaskins.spectrum.internal.BlockFocused;
+import com.greghaskins.spectrum.internal.BlockIgnore;
+import com.greghaskins.spectrum.internal.BlockTagging;
 import com.greghaskins.spectrum.internal.ConfiguredBlock;
 import com.greghaskins.spectrum.internal.Suite;
 import com.greghaskins.spectrum.internal.blocks.ConstructorBlock;
@@ -349,8 +352,11 @@ public final class Spectrum extends Runner {
   }
 
   /**
-   * Surround a {@link Block} with the {@code with} statement to add preconditions and metadata to
-   * it. E.g. <code>with(tags("foo"), () -&gt; {})</code>
+   * Surround a {@link com.greghaskins.spectrum.Block} with the {@code with} statement to add
+   * preconditions and metadata to it. E.g. <code>with(tags("foo"), () -&gt; {})</code>.<br>
+   * Note: preconditions and metadata can be chained using the
+   * {@link BlockConfigurationChain#and(BlockConfigurationChain)} method.
+   * E.g. <code>with(tags("foo").and(ignore()), () -&gt; {})</code>
    * 
    * @param configuration the chainable block configuration
    * @param block the enclosed block
@@ -396,7 +402,7 @@ public final class Spectrum extends Runner {
    * @return a chainable configuration that will ignore the block within a {@link #with}
    */
   public static BlockConfigurationChain ignore() {
-    return new BlockConfigurationChain().ignore();
+    return new BlockConfigurationChain().with(new BlockIgnore());
   }
 
   /**
@@ -406,7 +412,7 @@ public final class Spectrum extends Runner {
    * @return a chainable configuration that will ignore the block within a {@link #with}
    */
   public static BlockConfigurationChain ignore(final String reason) {
-    return new BlockConfigurationChain().ignore(reason);
+    return new BlockConfigurationChain().with(new BlockIgnore(reason));
   }
 
   /**
@@ -417,7 +423,7 @@ public final class Spectrum extends Runner {
    * @return a chainable configuration that has these tags set for the block in {@link #with}
    */
   public static BlockConfigurationChain tags(final String... tags) {
-    return new BlockConfigurationChain().tags(tags);
+    return new BlockConfigurationChain().with(new BlockTagging(tags));
   }
 
   /**
@@ -426,7 +432,7 @@ public final class Spectrum extends Runner {
    * @return a chainable configuration that will focus the suite or spec in the {@link #with}
    */
   public static BlockConfigurationChain focus() {
-    return new BlockConfigurationChain().focus();
+    return new BlockConfigurationChain().with(new BlockFocused());
   }
 
   /**

--- a/src/main/java/com/greghaskins/spectrum/internal/BlockConfigurable.java
+++ b/src/main/java/com/greghaskins/spectrum/internal/BlockConfigurable.java
@@ -1,0 +1,27 @@
+package com.greghaskins.spectrum.internal;
+
+/**
+ * Defines a configurable thing on a block.
+ */
+public interface BlockConfigurable<T> {
+  /**
+   * Return if this sort of configurable inherited by a child from a suite.
+   * @return true when the configurable is inheritable.
+   */
+  boolean inheritedByChild();
+
+  /**
+   * Modify the child according to this configurable.
+   * @param child to modify.
+   * @param state any known tagging filter criteria (used by tagging configurable).
+   */
+  void applyTo(final Child child, final TaggingFilterCriteria state);
+
+  /**
+   * Provide a merged configurable, based on the combination of this configurable
+   * and the input.
+   * @param other the configurable to merge with this. Must be of same type. Can be null.
+   * @return a new BlockConfigurable of the right type with the contents of both.
+   */
+  BlockConfigurable<T> merge(BlockConfigurable<?> other);
+}

--- a/src/main/java/com/greghaskins/spectrum/internal/BlockFocused.java
+++ b/src/main/java/com/greghaskins/spectrum/internal/BlockFocused.java
@@ -1,0 +1,27 @@
+package com.greghaskins.spectrum.internal;
+
+/**
+ * Created by friezea on 02/03/2017.
+ */
+public class BlockFocused implements BlockConfigurable<BlockFocused> {
+  @Override
+  public boolean inheritedByChild() {
+    // focus is not inherited
+
+    return false;
+  }
+
+  @Override
+  public void applyTo(Child child, TaggingFilterCriteria state) {
+    child.focus();
+  }
+
+  @Override
+  public BlockConfigurable<BlockFocused> merge(BlockConfigurable<?> other) {
+    // any focusing means future focusing
+    // so this will always add up to focused, regardless of what other
+    // may contain
+
+    return new BlockFocused();
+  }
+}

--- a/src/main/java/com/greghaskins/spectrum/internal/BlockIgnore.java
+++ b/src/main/java/com/greghaskins/spectrum/internal/BlockIgnore.java
@@ -1,0 +1,33 @@
+package com.greghaskins.spectrum.internal;
+
+/**
+ * A configurable that does ignoring.
+ */
+public class BlockIgnore implements BlockConfigurable<BlockIgnore> {
+  private String reason;
+
+  public BlockIgnore() {}
+
+  public BlockIgnore(String reason) {
+    this.reason = reason;
+  }
+
+  @Override
+  public boolean inheritedByChild() {
+    return true;
+  }
+
+  @Override
+  public void applyTo(Child child, TaggingFilterCriteria state) {
+    child.ignore();
+  }
+
+  @Override
+  public BlockConfigurable<BlockIgnore> merge(BlockConfigurable<?> other) {
+    // any ignoring means future ignoring
+    // so this will always add up to ignore, regardless of what other
+    // may contain
+
+    return new BlockIgnore();
+  }
+}

--- a/src/main/java/com/greghaskins/spectrum/internal/BlockTagging.java
+++ b/src/main/java/com/greghaskins/spectrum/internal/BlockTagging.java
@@ -1,0 +1,45 @@
+package com.greghaskins.spectrum.internal;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The tags of a given block.
+ */
+public class BlockTagging implements BlockConfigurable<BlockTagging> {
+  private Set<String> hasTags = new HashSet<>();
+
+  public BlockTagging(String... tags) {
+    Arrays.stream(tags).forEach(hasTags::add);
+  }
+
+  private BlockTagging(Set<String> tags) {
+    hasTags.addAll(tags);
+  }
+
+  @Override
+  public boolean inheritedByChild() {
+    return true;
+  }
+
+  @Override
+  public void applyTo(Child child, TaggingFilterCriteria state) {
+    if (!state.isAllowedToRun(hasTags)) {
+      child.ignore();
+    }
+  }
+
+  @Override
+  public BlockConfigurable<BlockTagging> merge(BlockConfigurable<?> other) {
+    BlockTagging merged = new BlockTagging(hasTags);
+    if (other != null) {
+      // the downcast is allowed because this is only called with an object
+      // of the same type as the parent merge routine is working type
+      // by type
+      merged.hasTags.addAll(((BlockTagging) other).hasTags);
+    }
+
+    return merged;
+  }
+}

--- a/src/test/java/specs/TaggedSpecs.java
+++ b/src/test/java/specs/TaggedSpecs.java
@@ -3,6 +3,7 @@ package specs;
 import static com.greghaskins.spectrum.Spectrum.beforeEach;
 import static com.greghaskins.spectrum.Spectrum.configure;
 import static com.greghaskins.spectrum.Spectrum.describe;
+import static com.greghaskins.spectrum.Spectrum.ignore;
 import static com.greghaskins.spectrum.Spectrum.it;
 import static com.greghaskins.spectrum.Spectrum.let;
 import static com.greghaskins.spectrum.Spectrum.tags;
@@ -40,6 +41,11 @@ public class TaggedSpecs {
         it("runs completely when its tag is in the includes list", () -> {
           final Result result = SpectrumHelper.run(getSuiteWithTagsIncluded());
           assertThat(result.getIgnoreCount(), is(0));
+        });
+
+        it("is ignored because though its tag is in the includes list it is ALSO ignored", () -> {
+          final Result result = SpectrumHelper.run(getIgnoredSuiteWithTagsIncluded());
+          assertThat(result.getIgnoreCount(), is(1));
         });
 
         it("does not run when it's missing from the includes", () -> {
@@ -219,6 +225,22 @@ public class TaggedSpecs {
 
         describe("A suite", with(tags("someTag"), () -> {
           it("has a spec that runs", () -> {
+            assertTrue(true);
+          });
+        }));
+      }
+    }
+
+    return Tagged.class;
+  }
+
+  private static Class<?> getIgnoredSuiteWithTagsIncluded() {
+    class Tagged {
+      {
+        configure().includeTags("someTag");
+
+        describe("A suite", with(tags("someTag").and(ignore()), () -> {
+          it("has an ignored spec that runs", () -> {
             assertTrue(true);
           });
         }));


### PR DESCRIPTION
to represent the configuration, so that it can be extended without (much) code change.

A proposed fix for #100 