### PR TITLE
Fix broken link for JUnitRuleExample class in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ to a fully hierarchical test execution report in your IDE.
 ## Getting Started
 
 - Read the feature overview below
-- Try our [quickstart walkthrough](docs/QuickstartWalkthrough.md)
+- Try our [quickstart walkthrough](doc/QuickstartWalkthrough.md)
 - Jump into the JavaDoc in [Spectrum.java](src/main/java/com/greghaskins/spectrum/Spectrum.java)
 
 ## Example

--- a/doc/JunitRules.md
+++ b/doc/JunitRules.md
@@ -74,7 +74,7 @@ The rules are applied and the test object created just in time for each atomic t
 
 ### Examples
 
-> See: [JUnitRulesExample](../src/test/java/specs/JUnitRulesExample.java),
+> See: [JUnitRuleExample](../src/test/java/specs/JUnitRuleExample.java),
 [MockitoSpecJUnitStyle](../src/test/java/specs/MockitoSpecJUnitStyle.java),
 [MockitoSpecWithRuleClasses](../src/test/java/specs/MockitoSpecWithRuleClasses.java),
 [SpringSpecJUnitStyle](../src/test/java/specs/SpringSpecJUnitStyle.java) and


### PR DESCRIPTION
Simple commit to fix a broken links in `JunitRules.md` and `README.md`.