### PR TITLE
Fixes for `beforeAll` failures

### DIFF
--- a/docs/JunitRules.md
+++ b/docs/JunitRules.md
@@ -87,8 +87,8 @@ The rules are applied and the test object created just in time for each atomic t
 ### What is Supported
 
 * `@ClassRule` is applied
-* `@BeforeAll` is applied
-* `@AfterAll` is applied
+* `@BeforeClass` is applied
+* `@AfterClass` is applied
 * `@Rule` objects:
   * `TestRule`s are applied at the level of each atomic test
   * `MethodRule`s are applied at the level of each atomic test

--- a/src/main/java/com/greghaskins/spectrum/dsl/specification/Specification.java
+++ b/src/main/java/com/greghaskins/spectrum/dsl/specification/Specification.java
@@ -146,7 +146,7 @@ public interface Specification {
    * @param block {@link Block} to run once before all specs in this suite
    */
   static void beforeAll(final Block block) {
-    DeclarationState.instance().addHook(before(new IdempotentBlock(block)), AppliesTo.EACH_CHILD,
+    DeclarationState.instance().addHook(before(new IdempotentBlock(block)), AppliesTo.ATOMIC_ONLY,
         Precedence.SET_UP);
   }
 

--- a/src/main/java/com/greghaskins/spectrum/internal/Suite.java
+++ b/src/main/java/com/greghaskins/spectrum/internal/Suite.java
@@ -218,7 +218,7 @@ public class Suite implements Parent, Child {
     } else if (childIsNotInFocus(child)) {
       reporting.fireTestIgnored(child.getDescription());
     } else {
-      this.hooks.forThisLevel().sorted().runAround(child.getDescription(), reporting,
+      addLeafHook(this.hooks.forThisLevel().sorted(), child).runAround(child.getDescription(), reporting,
           () -> runChildWithHooks(child, reporting));
     }
   }
@@ -228,7 +228,7 @@ public class Suite implements Parent, Child {
   }
 
   private void runChildWithHooks(final Child child, final RunReporting<Description, Failure> reporting) {
-    addLeafHook(getHooksFor(child).sorted(), child).runAround(child.getDescription(), reporting,
+    getHooksFor(child).sorted().runAround(child.getDescription(), reporting,
         () -> child.run(reporting));
 
   }

--- a/src/main/java/com/greghaskins/spectrum/internal/hooks/HookContext.java
+++ b/src/main/java/com/greghaskins/spectrum/internal/hooks/HookContext.java
@@ -62,17 +62,16 @@ public class HookContext implements Comparable<HookContext> {
      */
     GUARANTEED_CLEAN_UP_GLOBAL(2),
 
+    /**
+     * Set up code should run before the local context.
+     */
+    SET_UP(3),
 
     /**
      * Guaranteed tidy up code should be allowed to run no matter
      * what, once the test has started.
      */
-    GUARANTEED_CLEAN_UP_LOCAL(3),
-
-    /**
-     * Set up code should run before the local context.
-     */
-    SET_UP(4),
+    GUARANTEED_CLEAN_UP_LOCAL(4),
 
     /**
      * Local context - the order depends on declaration.

--- a/src/main/java/com/greghaskins/spectrum/internal/junit/RuleContext.java
+++ b/src/main/java/com/greghaskins/spectrum/internal/junit/RuleContext.java
@@ -161,15 +161,23 @@ public class RuleContext<T> implements Supplier<T> {
   }
 
   private Statement withAfterClasses(final Statement base) {
-    List<FrameworkMethod> afters = testClass.getAnnotatedMethods(AfterClass.class);
+    List<FrameworkMethod> afters = getAfterClassMethods();
 
     return afters.isEmpty() ? base : new RunAfters(base, afters, null);
   }
 
+  private List<FrameworkMethod> getAfterClassMethods() {
+    return testClass.getAnnotatedMethods(AfterClass.class);
+  }
+
   private Statement withBeforeClasses(final Statement base) {
-    List<FrameworkMethod> befores = testClass.getAnnotatedMethods(BeforeClass.class);
+    List<FrameworkMethod> befores = getBeforeClassMethods();
 
     return befores.isEmpty() ? base : new RunBefores(base, befores, null);
+  }
+
+  private List<FrameworkMethod> getBeforeClassMethods() {
+    return testClass.getAnnotatedMethods(BeforeClass.class);
   }
 
   private List<TestRule> getClassRules() {
@@ -198,7 +206,8 @@ public class RuleContext<T> implements Supplier<T> {
    * @return true if there are rules
    */
   boolean hasAnyJUnitAnnotations() {
-    return getClassRules().size() > 0 || hasAnyTestOrMethodRules();
+    return hasAnyTestOrMethodRules()
+        || getClassRules().size() + getAfterClassMethods().size() + getBeforeClassMethods().size() > 0;
   }
 
   /**

--- a/src/test/java/com/greghaskins/spectrum/SpectrumHelper.java
+++ b/src/test/java/com/greghaskins/spectrum/SpectrumHelper.java
@@ -12,6 +12,26 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SpectrumHelper {
+  // Allows us to hide a test class from IDE/test discovery
+  public static class NullRunner extends Runner {
+    private Class<?> clazz;
+
+    public NullRunner(Class<?> clazz) {
+      this.clazz = clazz;
+    }
+
+    @Override
+    public Description getDescription() {
+      // empty suite
+
+      return Description.createSuiteDescription(clazz);
+    }
+
+    @Override
+    public void run(RunNotifier notifier) {
+      // do nothing
+    }
+  }
 
   public static class RecordingListener extends RunListener {
     private List<Description> testsStarted = new ArrayList<>();
@@ -56,5 +76,4 @@ public class SpectrumHelper {
   private static Result runWithJUnit(final Runner runner) {
     return new JUnitCore().run(Request.runner(runner));
   }
-
 }

--- a/src/test/java/specs/JUnitRuleExample.java
+++ b/src/test/java/specs/JUnitRuleExample.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertThat;
 
 import com.greghaskins.spectrum.Spectrum;
 
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -20,9 +21,27 @@ import java.util.function.Supplier;
 
 @RunWith(Spectrum.class)
 public class JUnitRuleExample {
+  // mixins for the Spectrum native style of mixin
   public static class TempFolderRuleMixin {
     @Rule
     public TemporaryFolder tempFolderRule = new TemporaryFolder();
+  }
+
+  public static class JUnitBeforeClassExample {
+    public static String value;
+
+    @BeforeClass
+    public static void beforeClass() {
+      value = "Hello world";
+    }
+  }
+
+  // can also use native junit annotations
+  private static String classValue;
+
+  @BeforeClass
+  public static void beforeClass() {
+    classValue = "initialised";
   }
 
   {
@@ -45,6 +64,17 @@ public class JUnitRuleExample {
 
       it("has received a different instance of the rule-provided object each time", () -> {
         assertThat(ruleProvidedFoldersSeen.size(), is(3));
+      });
+
+      describe("with just a beforeClass mixin", () -> {
+        Supplier<JUnitBeforeClassExample> mixin = junitMixin(JUnitBeforeClassExample.class);
+        it("the mixin's before class has been called", () -> {
+          assertThat(JUnitBeforeClassExample.value, is("Hello world"));
+        });
+      });
+
+      it("has also initialised a class member owing to a local JUnit annotation", () -> {
+        assertThat(classValue, is("initialised"));
       });
     });
   }


### PR DESCRIPTION
Fixes for #110 and #109 further to #111 not quite fixing `beforeAll`.

Added additional tests and resolved a couple of minor glitches in docs and code for the JUnit rule support.