### PR TITLE
POC for expected exception implementation.

### DIFF
--- a/docs/ExceptionHandling.md
+++ b/docs/ExceptionHandling.md
@@ -1,0 +1,60 @@
+# Exception handling in tests
+
+Often in unit testing, we want to check that the system under test throws an error in a certain situation.
+
+In native JUnit there are a couple of ways you can specify the expected exceptions of a test:
+
+```java
+// tag the test like this
+@Test(expected=SomeException.class)
+public void throwingTest() {}
+
+// or use the expected exception rule in the test class
+@Rule
+public ExpectedException expected = ExpectedException.none();
+
+@Test
+public void throwingTest() {
+  expected.expect(RuntimeException.class);
+}
+```
+
+These are great. **They do not work with Spectrum!!!**
+
+Even though Spectrum supports JUnit `@Rule` both in the test class and with the `junitMixin` function, the JUnit `ExpectedException` mechanism does not work. This is because the test has already failed owing to Spectrum's error handling before the JUnit exception rule gets a chance to say it's _ok_.
+
+## Use assertion libraries instead
+
+Your favourite assertion library may already solve this problem. Spectrum does not require or recommend an assertion library, so you can use whatever you with. AssertJ's `assertThatThrownBy` is a good fit for this.
+
+E.g.
+
+```java
+it("expects a boom", () -> {
+   assertThatThrownBy(() -> { throw new Exception("boom!"); }).isInstanceOf(Exception.class)
+                                                             .hasMessageContaining("boom");
+}
+```
+
+## Spectrum Expected Exceptions
+
+Spectrum provides the following syntax for expecting exceptions in your specs:
+
+```java
+describe("Some suite", () -> {
+  // in the parent of the test in the hierarchy, you add a call to `expectExceptions()`
+  // this gives you an `ExceptionExpectation` object you can set expectations in
+  ExceptionExpectation expectation = expectExceptions();
+  it("correctly goes bang", () -> {
+    // set the expectations here
+    expectation.expectMessage("bang");
+    throw new RuntimeException("bang");
+  });
+});
+```
+
+The `ExceptionExpectation` object is refreshed for each spec and is hooked into the execution of the specs so that if they end in an unexpected exception, there's a custom failure and if they do not end in an exception when they should, there's also a failure.
+
+If you do not call any of the `expect...` functions on `ExceptionExpectation` then your spec can end without exception and pass. The default is for there to be no expectation whatsoever.
+
+All calls to `expect...` **add** to the existing expectations. There's an `expect(CharSequence, Predicate)` overload so you can add a validating `Predicate` of your own beyond the existing methods provided.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Spectrum also supports:
 - Compatibility with most existing JUnit tools; no configuration required
 - Plugging in familiar JUnit-friendly libraries like `MockitoJUnit` or `SpringJUnit` [via JUnit `@Rule`s handling](JunitRules.md).
 - Tagging specs for [selective running](FocusingAndIgnoring.md) or adding [configuration](Configuration.md) including [timeouts](Timeout.md)
+- [Expecting exceptions](ExceptionHandling.md) within specs
 - Mixing Spectrum tests and normal JUnit tests in the same project suite
 - RSpec-style `aroundEach` and `aroundAll` hooks for advanced users and plugin authors
 

--- a/src/main/java/com/greghaskins/spectrum/ExceptionExpectation.java
+++ b/src/main/java/com/greghaskins/spectrum/ExceptionExpectation.java
@@ -1,0 +1,45 @@
+package com.greghaskins.spectrum;
+
+import java.util.function.Predicate;
+
+/**
+ * Allows expectations for exceptions to be specified by a spec.
+ */
+public interface ExceptionExpectation {
+  /**
+   * Require that the exception type match the given type.
+   * @param typeOfException the thrown exception must be of this exact type.
+   */
+  void expect(final Class<?> typeOfException);
+
+  /**
+   * General purpose expectation. "and"ed to all other expectations called on the object.
+   * @param description description of the expectation for error reporting
+   * @param exceptionIsExpected defines a single check on the exception that must be valid
+   */
+  void expect(final String description, final Predicate<Throwable> exceptionIsExpected);
+
+  /**
+   * Expect the whole of the message of the exception is as provided.
+   * @param message expected message
+   */
+  void expectMessage(final CharSequence message);
+
+  /**
+   * Expect the message of the exception to contain.
+   * @param substring expected substring
+   */
+  void expectMessageContains(final CharSequence substring);
+
+  /**
+   * When a throwable is thrown by the test check that it is valid.
+   * @param thrown exception thrown
+   * @throws Throwable the given exception is rethrown when no exception is expected
+   */
+  void validateThrowable(final Throwable thrown) throws Throwable;
+
+  /**
+   * When the test finishes with nothing thrown, check that this was expected.
+   */
+  void verifyNoExceptionExpected();
+}

--- a/src/main/java/com/greghaskins/spectrum/internal/Suite.java
+++ b/src/main/java/com/greghaskins/spectrum/internal/Suite.java
@@ -1,6 +1,7 @@
 package com.greghaskins.spectrum.internal;
 
 import static com.greghaskins.spectrum.internal.configuration.BlockConfiguration.merge;
+import static com.greghaskins.spectrum.internal.configuration.ConfiguredBlock.configurationFromBlock;
 
 import com.greghaskins.spectrum.Block;
 import com.greghaskins.spectrum.internal.configuration.BlockConfiguration;
@@ -112,14 +113,29 @@ public class Suite implements Parent, Child {
   }
 
   private Child configuredChild(final Child child, final Block block) {
-    merge(this.configuration.forChild(), ConfiguredBlock.configurationFromBlock(block))
+    merge(this.configuration.forChild(), configurationFromBlock(block))
         .applyTo(child, this.tagging);
 
     return child;
   }
 
+  /**
+   * Attach any configuration attached to the given block to the configuration of my suite.
+   * Block configuration is provided when a {@link ConfiguredBlock} is created using the
+   * {@link ConfiguredBlock#with(BlockConfiguration, Block)} function to wrap a normal
+   * {@link Block}
+   * @param block the block with a configuration
+   */
   public void applyConfigurationFromBlock(Block block) {
-    this.configuration = merge(this.configuration, ConfiguredBlock.configurationFromBlock(block));
+    applyConfiguration(configurationFromBlock(block));
+  }
+
+  /**
+   * Attach an explicitly created configuration to the current suite.
+   * @param configuration to attach to this suite and its descendents
+   */
+  public void applyConfiguration(BlockConfiguration configuration) {
+    this.configuration = merge(this.configuration, configuration);
     this.configuration.applyTo(this, this.tagging);
   }
 

--- a/src/main/java/com/greghaskins/spectrum/internal/configuration/BlockConfiguration.java
+++ b/src/main/java/com/greghaskins/spectrum/internal/configuration/BlockConfiguration.java
@@ -65,8 +65,24 @@ public class BlockConfiguration {
     add(new BlockTagging());
   }
 
+  /**
+   * Construct an empty block configuration.
+   * @return a block configuration with no special configuration in it
+   */
   public static BlockConfiguration defaultConfiguration() {
     return new BlockConfiguration();
+  }
+
+  /**
+   * Construct BlockConfiguration from a single configurable.
+   * @param configurable to start with
+   * @return a block configuration with the configurable in it
+   */
+  public static BlockConfiguration of(BlockConfigurable<?> configurable) {
+    BlockConfiguration configuration = new BlockConfiguration();
+    configuration.add(configurable);
+
+    return configuration;
   }
 
   /**

--- a/src/main/java/com/greghaskins/spectrum/internal/exception/ExceptionConfiguration.java
+++ b/src/main/java/com/greghaskins/spectrum/internal/exception/ExceptionConfiguration.java
@@ -1,0 +1,37 @@
+package com.greghaskins.spectrum.internal.exception;
+
+import com.greghaskins.spectrum.internal.Child;
+import com.greghaskins.spectrum.internal.LeafChild;
+import com.greghaskins.spectrum.internal.configuration.BlockConfigurable;
+import com.greghaskins.spectrum.internal.configuration.TaggingFilterCriteria;
+import com.greghaskins.spectrum.internal.hooks.HookContext;
+
+/**
+ * Provide exception handling as a configuration.
+ */
+public class ExceptionConfiguration implements BlockConfigurable<ExceptionConfiguration> {
+  private ExceptionExpectationProxy expectationProxy;
+
+  public ExceptionConfiguration(ExceptionExpectationProxy expectationProxy) {
+    this.expectationProxy = expectationProxy;
+  }
+
+  @Override
+  public boolean inheritedByChild() {
+    return true;
+  }
+
+  @Override
+  public void applyTo(Child child, TaggingFilterCriteria state) {
+    if (child instanceof LeafChild) {
+      ((LeafChild) child).addLeafHook(expectationProxy.asHook(), HookContext.Precedence.ROOT);
+    }
+  }
+
+  @Override
+  public BlockConfigurable<ExceptionConfiguration> merge(BlockConfigurable<?> other) {
+    // always supersedes higher level definition
+
+    return this;
+  }
+}

--- a/src/main/java/com/greghaskins/spectrum/internal/exception/ExceptionExpectationProxy.java
+++ b/src/main/java/com/greghaskins/spectrum/internal/exception/ExceptionExpectationProxy.java
@@ -1,0 +1,77 @@
+package com.greghaskins.spectrum.internal.exception;
+
+import com.greghaskins.spectrum.Block;
+import com.greghaskins.spectrum.ExceptionExpectation;
+import com.greghaskins.spectrum.internal.configuration.BlockConfiguration;
+import com.greghaskins.spectrum.internal.hooks.Hook;
+import com.greghaskins.spectrum.internal.hooks.NonReportingHook;
+
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ * Proxy to the exception expectation supplier.
+ */
+public class ExceptionExpectationProxy implements ExceptionExpectation {
+  private Supplier<ExceptionExpectation> supplier;
+
+  public ExceptionExpectationProxy(final Supplier<ExceptionExpectation> supplier) {
+    this.supplier = supplier;
+  }
+
+  @Override
+  public void expect(final Class<?> typeOfException) {
+    proxyObject().expect(typeOfException);
+  }
+
+  @Override
+  public void expect(final String description, final Predicate<Throwable> exceptionIsExpected) {
+    proxyObject().expect(description, exceptionIsExpected);
+  }
+
+  @Override
+  public void validateThrowable(final Throwable thrown) throws Throwable {
+    proxyObject().validateThrowable(thrown);
+  }
+
+  @Override
+  public void verifyNoExceptionExpected() {
+    proxyObject().verifyNoExceptionExpected();
+  }
+
+  @Override
+  public void expectMessage(final CharSequence message) {
+    proxyObject().expectMessage(message);
+  }
+
+  @Override
+  public void expectMessageContains(final CharSequence substring) {
+    proxyObject().expectMessageContains(substring);
+  }
+
+  public BlockConfiguration asConfiguration() {
+    return BlockConfiguration.of(new ExceptionConfiguration(this));
+  }
+
+  NonReportingHook asHook() {
+    return NonReportingHook.nonReportingHookFrom(Hook.from(this::verifyExceptionBehaviour));
+  }
+
+  private ExceptionExpectation proxyObject() {
+    return supplier.get();
+  }
+
+  private void verifyExceptionBehaviour(final Block block) throws Throwable {
+    boolean hasCaught = false;
+    try {
+      block.run();
+    } catch (Throwable thrown) {
+      hasCaught = true;
+      validateThrowable(thrown);
+    } finally {
+      if (!hasCaught) {
+        verifyNoExceptionExpected();
+      }
+    }
+  }
+}

--- a/src/main/java/com/greghaskins/spectrum/internal/exception/ExceptionExpecter.java
+++ b/src/main/java/com/greghaskins/spectrum/internal/exception/ExceptionExpecter.java
@@ -1,0 +1,62 @@
+package com.greghaskins.spectrum.internal.exception;
+
+import com.greghaskins.spectrum.ExceptionExpectation;
+
+import org.junit.Assert;
+
+import java.util.function.Predicate;
+
+/**
+ * Object that can be configured to expect exceptions.
+ */
+public class ExceptionExpecter implements ExceptionExpectation {
+  private Predicate<Throwable> toExpect;
+  private StringBuilder expectationDescription = new StringBuilder();
+
+  @Override
+  public void expect(final Class<?> typeOfException) {
+    expect("type: " + typeOfException.getCanonicalName(),
+        throwable -> throwable.getClass().equals(typeOfException));
+  }
+
+  @Override
+  public void expect(final String description, final Predicate<Throwable> exceptionIsExpected) {
+    if (expectationDescription.length() == 0) {
+      expectationDescription.append("Expected ");
+    } else {
+      expectationDescription.append(", ");
+    }
+
+    expectationDescription.append(description);
+
+    // combine the expectations into a chain
+    toExpect = toExpect == null ? exceptionIsExpected : toExpect.and(exceptionIsExpected);
+  }
+
+  @Override
+  public void expectMessage(final CharSequence message) {
+    expect("message: " + message, throwable -> throwable.getMessage().equals(message));
+  }
+
+  @Override
+  public void expectMessageContains(final CharSequence substring) {
+    expect("message contains: " + substring, throwable -> throwable.getMessage().contains(substring));
+  }
+
+  @Override
+  public void validateThrowable(Throwable thrown) throws Throwable {
+    if (toExpect == null) {
+      throw thrown;
+    }
+    if (!toExpect.test(thrown)) {
+      Assert.fail(expectationDescription.toString() + " but got " + thrown.toString());
+    }
+  }
+
+  @Override
+  public void verifyNoExceptionExpected() {
+    if (toExpect != null) {
+      Assert.fail(expectationDescription.toString() + " but ended with no exception");
+    }
+  }
+}

--- a/src/test/java/specs/ExpectedExceptionSpecs.java
+++ b/src/test/java/specs/ExpectedExceptionSpecs.java
@@ -1,0 +1,251 @@
+package specs;
+
+import static com.greghaskins.spectrum.Configure.junitMixin;
+import static com.greghaskins.spectrum.Spectrum.describe;
+import static com.greghaskins.spectrum.Spectrum.it;
+import static com.greghaskins.spectrum.dsl.specification.Specification.context;
+import static com.greghaskins.spectrum.dsl.specification.Specification.expectExceptions;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.greghaskins.spectrum.ExceptionExpectation;
+import com.greghaskins.spectrum.Spectrum;
+import com.greghaskins.spectrum.SpectrumHelper;
+
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+@RunWith(Spectrum.class)
+public class ExpectedExceptionSpecs {
+  {
+    describe("Expected exceptions", () -> {
+      context("using JUnit ExpectedException Rule", () -> {
+        it("will not work with a member variable in test class as the "
+            + "error is caught before the rule catches it",
+            () -> {
+              final Result result = SpectrumHelper.run(classWithLocalExceptionMember());
+              assertThat(result.getFailureCount(), is(1));
+            });
+
+        it("nor will it work if using a junitMixin", () -> {
+          final Result result = SpectrumHelper.run(classWithExceptionMixin());
+          assertThat(result.getFailureCount(), is(1));
+        });
+      });
+
+      context("using Spectrum expectedException configuration", () -> {
+        it("will fail on unexpected exception", () -> {
+          final Result result = SpectrumHelper.run(() -> {
+            ExceptionExpectation expectation = expectExceptions();
+            describe("Expect exceptions", () -> {
+              it("throws unexpected exception", () -> {
+                expectation.expect(IOException.class);
+                throw new RuntimeException("boom");
+              });
+            });
+          });
+          assertThat(result.getFailureCount(), is(1));
+          assertThat(result.getFailures().get(0).getMessage(),
+              is("Expected type: java.io.IOException but got java.lang.RuntimeException: boom"));
+        });
+
+        it("will pass on expected exception by class", () -> {
+          final Result result = SpectrumHelper.run(() -> {
+            ExceptionExpectation expectation = expectExceptions();
+            describe("Expect exceptions", () -> {
+              it("throws expected exception", () -> {
+                expectation.expect(IOException.class);
+                throw new IOException("boom");
+              });
+            });
+          });
+          assertThat(result.getFailureCount(), is(0));
+          assertThat(result.getRunCount(), is(1));
+        });
+
+        it("will pass on expected exception by message", () -> {
+          final Result result = SpectrumHelper.run(() -> {
+            ExceptionExpectation expectation = expectExceptions();
+            describe("Expect exceptions", () -> {
+              it("throws expected exception", () -> {
+                expectation.expectMessage("boom");
+                throw new IOException("boom");
+              });
+            });
+          });
+          assertThat(result.getFailureCount(), is(0));
+          assertThat(result.getRunCount(), is(1));
+        });
+
+        it("will pass on expected exception by message and class", () -> {
+          final Result result = SpectrumHelper.run(() -> {
+            ExceptionExpectation expectation = expectExceptions();
+            describe("Expect exceptions", () -> {
+              it("throws expected exception", () -> {
+                expectation.expectMessage("boom");
+                expectation.expect(IOException.class);
+                throw new IOException("boom");
+              });
+            });
+          });
+          assertThat(result.getFailureCount(), is(0));
+          assertThat(result.getRunCount(), is(1));
+        });
+
+        it("will fail on expected exception by message being wrong when class is right", () -> {
+          final Result result = SpectrumHelper.run(() -> {
+            ExceptionExpectation expectation = expectExceptions();
+            describe("Expect exceptions", () -> {
+              it("throws expected exception", () -> {
+                expectation.expectMessage("boom");
+                expectation.expect(IOException.class);
+                throw new IOException("not boom!");
+              });
+            });
+          });
+          assertThat(result.getFailureCount(), is(1));
+          assertThat(result.getFailures().get(0).getMessage(), is(
+              "Expected message: boom, type: java.io.IOException "
+                  + "but got java.io.IOException: not boom!"));
+        });
+
+        it("will pass on expected exception by part of message", () -> {
+          final Result result = SpectrumHelper.run(() -> {
+            ExceptionExpectation expectation = expectExceptions();
+            describe("Expect exceptions", () -> {
+              it("throws expected exception", () -> {
+                expectation.expectMessageContains("boom");
+                expectation.expect(IOException.class);
+                throw new IOException("This exception went boom");
+              });
+            });
+          });
+          assertThat(result.getFailureCount(), is(0));
+          assertThat(result.getRunCount(), is(1));
+        });
+
+        it("will fail on expected exception by part of message", () -> {
+          final Result result = SpectrumHelper.run(() -> {
+            ExceptionExpectation expectation = expectExceptions();
+            describe("Expect exceptions", () -> {
+              it("throws expected exception", () -> {
+                expectation.expectMessageContains("boom");
+                expectation.expect(IOException.class);
+                throw new IOException("This exception is a bang");
+              });
+            });
+          });
+          assertThat(result.getFailureCount(), is(1));
+        });
+
+        it("will fail on expected exception not being thrown", () -> {
+          final Result result = SpectrumHelper.run(() -> {
+            ExceptionExpectation expectation = expectExceptions();
+            describe("Expect exceptions", () -> {
+              it("throws expected exception", () -> {
+                expectation.expectMessageContains("boom");
+              });
+            });
+          });
+          assertThat(result.getFailureCount(), is(1));
+          assertThat(result.getFailures().get(0).getMessage(), is(
+              "Expected message contains: boom but ended with no exception"));
+        });
+
+        it("will fail on expected exception predicate", () -> {
+          final Result result = SpectrumHelper.run(() -> {
+            ExceptionExpectation expectation = expectExceptions();
+            describe("Expect exceptions", () -> {
+              it("throws expected exception", () -> {
+                expectation.expect("Should be UnsupportedOperation",
+                    thrown -> thrown instanceof UnsupportedOperationException);
+                throw new RuntimeException("Not what you were expecting");
+              });
+            });
+          });
+          assertThat(result.getFailureCount(), is(1));
+          assertThat(result.getFailures().get(0).getMessage(), is(
+              "Expected Should be UnsupportedOperation but "
+                  + "got java.lang.RuntimeException: Not what you were expecting"));
+        });
+
+        it("will fail on actual exception when no expectation set", () -> {
+          final Result result = SpectrumHelper.run(() -> {
+            ExceptionExpectation expectation = expectExceptions();
+            describe("Expect exceptions", () -> {
+              it("throws", () -> {
+                throw new RuntimeException("Boom!");
+              });
+            });
+          });
+          assertThat(result.getFailureCount(), is(1));
+          assertThat(result.getFailures().get(0).getMessage(), is(
+              "Boom!"));
+        });
+
+        context("road testing passing tests with a shared expectation object", () -> {
+          ExceptionExpectation expectation = expectExceptions();
+          it("correctly goes bang", () -> {
+            expectation.expectMessage("bang");
+            throw new RuntimeException("bang");
+          });
+
+          it("does not throw", () -> {
+            // passes without exception
+          });
+
+          it("does a boom", () -> {
+            expectation.expectMessageContains("boom");
+            expectation.expect(IOException.class);
+            throw new IOException("this went boom!");
+          });
+
+          it("wants an unsupported operation", () -> {
+            expectation.expect(UnsupportedOperationException.class);
+            throw new UnsupportedOperationException();
+          });
+        });
+      });
+    });
+  }
+
+  private Class<?> classWithExceptionMixin() {
+    class ExceptionMixin {
+      @Rule
+      public ExpectedException expectedException = ExpectedException.none();
+    }
+
+    class ClassWithExceptionMixin {
+      {
+        Supplier<ExceptionMixin> exceptionMixin = junitMixin(ExceptionMixin.class);
+        it("should expect this exception", () -> {
+          exceptionMixin.get().expectedException.expect(RuntimeException.class);
+          throw new RuntimeException("boom");
+        });
+      }
+    }
+
+    return ClassWithExceptionMixin.class;
+  }
+
+  private Class<?> classWithLocalExceptionMember() {
+    class ClassWithExceptionRuleAsMember {
+      @Rule
+      public ExpectedException expectedException = org.junit.rules.ExpectedException.none();
+
+      {
+        it("should expect this exception", () -> {
+          expectedException.expect(RuntimeException.class);
+          throw new RuntimeException("boom");
+        });
+      }
+    }
+
+    return ClassWithExceptionRuleAsMember.class;
+  }
+}


### PR DESCRIPTION
A potential implementation for #121 

This was a POC I put together, provided as a PR for discussion.

I agree with the idea that things like this are done well with assertion frameworks. My experience with JUnit and AssertJ suggests that _it takes all sorts_. In that some things are better expressed in assertions and some things read easier another way.

So

```java
expect(object::method)
    .to(
        raise(SomeException.class));

// vs

exceptionExpectations.expect(SomeException.class);
object.method();
```

Both read well